### PR TITLE
Include LDAP Integration demo in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Miscellaneous utilities that make it easier to make, manage, and run demos
 - [Simple Cluster](demos/simple-cluster/README.md)
 - [Certificate Authority](demos/certificate-authority/README.md)
 - [Auto-Failover Cluster](demos/auto-failover/README.md)
+- [LDAP Sync and Authentication](demos/ldap-integration/README.md)
 
 ## Tools
 - [Generate Signed Certificates](tools/simple-certificates/)


### PR DESCRIPTION
This PR adds the LDAP Integration demo to the list of demos in the README at the repository root. This means that it is more easily discoverable from the project landing page on Github.

Connected to #25 