### PR TITLE
Add followers to AWS Cluster demo

### DIFF
--- a/demos/aws-cluster/1.1_init_followers
+++ b/demos/aws-cluster/1.1_init_followers
@@ -1,0 +1,64 @@
+#!/bin/bash -eux
+
+: ${SSH_KEY_FILE?"Need to set SSH_KEY_FILE"}
+
+source bin/lib/aws_context
+source bin/lib/conjur_context
+
+SEED_DIR="./tmp/conjur/seeds"
+
+function create_follower_seed() {
+  local filename=$1
+
+  mkdir -p $SEED_DIR
+
+  # Create Follower Seed
+  ssh -i "$SSH_KEY_FILE" \
+    -o "StrictHostKeyChecking no" \
+    core@$MASTER_1_PUBLIC /bin/bash << EOF
+    docker exec conjur-appliance bash -c " \
+      evoke seed follower "$LB_FOLLOWER_DNS" "$LB_DNS" > "/opt/conjur/backup/$filename"
+    "
+EOF
+
+  # Copy seed to host
+  scp -i "$SSH_KEY_FILE" \
+    -o "StrictHostKeyChecking no" \
+    "core@$MASTER_1_PUBLIC:/opt/conjur/backup/$filename" \
+    "$SEED_DIR/$filename"
+}
+
+function configure_follower() {
+  local follower_public=$1
+  local filename=$2
+
+  # Copy seed
+  scp -i "$SSH_KEY_FILE" \
+    -o "StrictHostKeyChecking no" \
+    "$SEED_DIR/$filename" \
+    "core@$follower_public:~/$filename"
+    
+  # Configure node
+  ssh -i "$SSH_KEY_FILE" \
+    -o "StrictHostKeyChecking no" \
+    core@$follower_public /bin/bash << EOF
+    sudo mv "\$HOME/$filename" "/opt/conjur/backup/$filename"
+    
+    docker exec conjur-appliance \
+      evoke unpack seed "/opt/conjur/backup/$filename"
+
+    docker exec conjur-appliance \
+      evoke configure follower
+EOF
+}
+
+function configure_followers() {
+  for follower in $FOLLOWERS_PUBLIC; do 
+    echo "Configuring follower on '$follower'..."
+    configure_follower "$follower" "follower-seed.tar"
+  done
+}
+
+create_follower_seed "follower-seed.tar"
+
+configure_followers

--- a/demos/aws-cluster/1_init_cluster
+++ b/demos/aws-cluster/1_init_cluster
@@ -17,6 +17,9 @@ function configure_master() {
       --master-altnames "$LB_DNS,$MASTER_2_PRIVATE,$MASTER_3_PRIVATE" \
       -p "$CONJUR_ADMIN_PASSWORD" \
       "$CONJUR_ACCOUNT"
+
+    docker exec conjur-appliance \
+      evoke ca issue --force $LB_FOLLOWER_DNS
 EOF
 }
 

--- a/demos/aws-cluster/README.md
+++ b/demos/aws-cluster/README.md
@@ -92,8 +92,11 @@ To initially install the cluster:
     Successful Health Checks: 10
     ```
 
-4. Deploy a Follower in AWS
-    > TBD
+4. (Optional) Deploy Followers in AWS
+    To also configure followers with the cluster, run the command:
+    ```
+    $ ./1.1_init_followers
+    ```
 
 
 ## HA Scenarios

--- a/demos/aws-cluster/bin/lib/aws_context
+++ b/demos/aws-cluster/bin/lib/aws_context
@@ -3,6 +3,9 @@
 export LB_DNS_DEFAULT=$(terraform output conjur_master_lb_public)
 export LB_DNS="${LB_DNS:-${LB_DNS_DEFAULT}}"
 
+export LB_FOLLOWER_DNS_DEFAULT=$(terraform output conjur_follower_lb_public)
+export LB_FOLLOWER_DNS="${LB_FOLLOWER_DNS:-${LB_FOLLOWER_DNS_DEFAULT}}"
+
 export MASTER_1_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.value[0]')
 export MASTER_1_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.value[0]')
 
@@ -11,3 +14,6 @@ export MASTER_2_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq 
 
 export MASTER_3_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.value[2]')
 export MASTER_3_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.value[2]')
+
+# Follower public DNS address, 1 per line
+export FOLLOWERS_PUBLIC=$(terraform output -json conjur_follower_nodes_public | jq -r '.value | .[]')


### PR DESCRIPTION
This PR updates the AWS Cluster demo to add AWS instances for followers and a script to optionally configure them.

Connected to #33 