### PR TITLE
Update demo automation scripts with EULA

### DIFF
--- a/demos/aws-authentication/README.md
+++ b/demos/aws-authentication/README.md
@@ -76,7 +76,7 @@ IAM Role
 
   $ sudo docker load --input /src/conjur-v5-rc1.tar
   $ sudo docker run --name conjur -d --restart=always --security-opt seccomp:unconfined -p "443:443" -e "CONJUR_AUTHENTICATORS=authn-iam/staging" registry.tld/conjur-appliance:5.0.0-rc1
-  sudo docker exec conjur evoke configure master -h ec2-34-224-2-198.compute-1.amazonaws.com -p secret demo
+  sudo docker exec conjur evoke configure master --accept-eula -h ec2-34-224-2-198.compute-1.amazonaws.com -p secret demo
   ```
 
 * Load Policy (locally, after setting the `host` variable in the `./cli` file)

--- a/demos/aws-cluster/1_init_cluster
+++ b/demos/aws-cluster/1_init_cluster
@@ -13,6 +13,7 @@ function configure_master() {
     core@$MASTER_1_PUBLIC /bin/bash << EOF
     docker exec conjur-appliance \
       evoke configure master \
+      \$(docker exec conjur-appliance evoke configure master --help | grep -q accept-eula && echo "--accept-eula") \
       -h "$MASTER_1_PRIVATE" \
       --master-altnames "$LB_DNS,$MASTER_2_PRIVATE,$MASTER_3_PRIVATE" \
       -p "$CONJUR_ADMIN_PASSWORD" \

--- a/demos/aws-cluster/bin/lib/active_master
+++ b/demos/aws-cluster/bin/lib/active_master
@@ -8,4 +8,4 @@ info_response=$(curl -ks "https://$LB_DNS/info")
 export ACTIVE_MASTER_PRIVATE_DNS=$(echo $info_response | jq -r '.configuration.conjur.hostname')
 
 private_node_dns_list=$(terraform output -json conjur_master_nodes_private)
-export ACTIVE_MASTER_NUM=$(echo $private_node_dns_list | jq ".value | index(\"$ACTIVE_MASTER_PRIVATE_DNS\") + 1")
+export ACTIVE_MASTER_NUM=$(echo $private_node_dns_list | jq ". | index(\"$ACTIVE_MASTER_PRIVATE_DNS\") + 1")

--- a/demos/aws-cluster/bin/lib/aws_context
+++ b/demos/aws-cluster/bin/lib/aws_context
@@ -6,14 +6,14 @@ export LB_DNS="${LB_DNS:-${LB_DNS_DEFAULT}}"
 export LB_FOLLOWER_DNS_DEFAULT=$(terraform output conjur_follower_lb_public)
 export LB_FOLLOWER_DNS="${LB_FOLLOWER_DNS:-${LB_FOLLOWER_DNS_DEFAULT}}"
 
-export MASTER_1_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.value[0]')
-export MASTER_1_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.value[0]')
+export MASTER_1_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.[0]')
+export MASTER_1_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.[0]')
 
-export MASTER_2_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.value[1]')
-export MASTER_2_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.value[1]')
+export MASTER_2_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.[1]')
+export MASTER_2_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.[1]')
 
-export MASTER_3_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.value[2]')
-export MASTER_3_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.value[2]')
+export MASTER_3_PRIVATE=$(terraform output -json conjur_master_nodes_private | jq -r '.[2]')
+export MASTER_3_PUBLIC=$(terraform output -json conjur_master_nodes_public | jq -r '.[2]')
 
 # Follower public DNS address, 1 per line
-export FOLLOWERS_PUBLIC=$(terraform output -json conjur_follower_nodes_public | jq -r '.value | .[]')
+export FOLLOWERS_PUBLIC=$(terraform output -json conjur_follower_nodes_public | jq -r '.[]')

--- a/demos/aws-cluster/main.tf
+++ b/demos/aws-cluster/main.tf
@@ -81,7 +81,7 @@ resource "aws_security_group" "lb" {
 resource "aws_elb" "lb" {
   name = "${var.resource_prefix}conjur-ha-lb"
 
-  subnets             = ["${data.aws_subnet.subnet.*.id}"]
+  subnets             = "${data.aws_subnet.subnet.*.id}"
   security_groups     = ["${aws_security_group.lb.id}"]
 
   # API and UI
@@ -125,7 +125,7 @@ resource "aws_elb" "lb" {
 resource "aws_elb" "follower_lb" {
   name = "${var.resource_prefix}conjur-ha-follower-lb"
 
-  subnets             = ["${data.aws_subnet.subnet.*.id}"]
+  subnets             = "${data.aws_subnet.subnet.*.id}"
   security_groups     = ["${aws_security_group.lb.id}"]
 
   # API and UI
@@ -212,7 +212,7 @@ resource "aws_instance" "conjur_master_node" {
 }
 
 resource "aws_elb_attachment" "lb_nodes" {
-  count     = "${aws_instance.conjur_master_node.count}"
+  count     = "${length(aws_instance.conjur_master_node)}"
   elb      = "${aws_elb.lb.id}"
   instance = "${element(aws_instance.conjur_master_node.*.id, count.index)}"
 }
@@ -266,7 +266,7 @@ resource "aws_instance" "conjur_follower_node" {
 }
 
 resource "aws_elb_attachment" "follower_lb_nodes" {
-  count     = "${aws_instance.conjur_follower_node.count}"
+  count     = "${length(aws_instance.conjur_follower_node)}"
   elb      = "${aws_elb.follower_lb.id}"
   instance = "${element(aws_instance.conjur_follower_node.*.id, count.index)}"
 }

--- a/demos/cluster/start
+++ b/demos/cluster/start
@@ -53,6 +53,7 @@ fi
 
 docker-compose exec conjur-master-1.mycompany.local bash -c "
   evoke configure master \
+  --accept-eula \
   -h conjur-master-1.mycompany.local \
   -p secret demo
 "

--- a/demos/ldap-integration/start
+++ b/demos/ldap-integration/start
@@ -24,6 +24,7 @@ docker-compose up -d --no-deps conjur-master.mycompany.local conjur-follower.myc
 
 docker-compose exec conjur-master.mycompany.local bash -c "
   evoke configure master \
+  --accept-eula \
   -h conjur-master.mycompany.local \
   -p secret demo
 "


### PR DESCRIPTION
This PR:
- Updates the master configuration scripts for demos to include EULA acceptance.
- Updates the AWS cluster demo to work correctly with Terraform 0.12