### PR TITLE
Handle the conjur-intro PS upgrade to 9.4.

### DIFF
--- a/demos/certificate-authority/mutual-tls/docker-compose.yml
+++ b/demos/certificate-authority/mutual-tls/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "80"
 
   database:
-    image: postgres:9.3
+    image: postgres:9.4
 
   cli:
     image: cyberark/conjur-cli:5


### PR DESCRIPTION
It is a prerequisite for the audit atomicity.
New data type JsonB was introduced in PS9.4 and is used by the audit.