### PR TITLE
Minor fix to the client and client-follower

### DIFF
--- a/demos/cluster/docker-compose.yml
+++ b/demos/cluster/docker-compose.yml
@@ -81,7 +81,7 @@ services:
 
   client:
     image: cyberark/conjur-cli:5
-    working_dir:  -w /src/cli
+    working_dir:  /src/cli
     environment:
       CONJUR_APPLIANCE_URL: https://conjur-master-1.mycompany.local
       CONJUR_ACCOUNT: demo
@@ -89,10 +89,12 @@ services:
     volumes:
       - .:/src/cli
       - ./cli_cache/master:/root
+    entrypoint: sleep
+    command: infinity
 
   follower-client:
     image: cyberark/conjur-cli:5
-    working_dir:  -w /src/cli
+    working_dir:  /src/cli
     environment:
       CONJUR_APPLIANCE_URL: https://conjur-follower.mycompany.local
       CONJUR_ACCOUNT: demo
@@ -100,6 +102,8 @@ services:
     volumes:
       - .:/src/cli
       - ./cli_cache/follower:/root
+    entrypoint: sleep
+    command: infinity
 
 volumes:
   backups:

--- a/demos/cluster/docker-compose.yml
+++ b/demos/cluster/docker-compose.yml
@@ -89,21 +89,12 @@ services:
     volumes:
       - .:/src/cli
       - ./cli_cache/master:/root
-    entrypoint: sleep
-    command: infinity
 
   follower-client:
     image: cyberark/conjur-cli:5
     working_dir:  /src/cli
     environment:
-      CONJUR_APPLIANCE_URL: https://conjur-follower.mycompany.local
       CONJUR_ACCOUNT: demo
       CONJUR_AUTHN_LOGIN: admin
     volumes:
       - .:/src/cli
-      - ./cli_cache/follower:/root
-    entrypoint: sleep
-    command: infinity
-
-volumes:
-  backups:

--- a/demos/cluster/docker-compose.yml
+++ b/demos/cluster/docker-compose.yml
@@ -94,7 +94,12 @@ services:
     image: cyberark/conjur-cli:5
     working_dir:  /src/cli
     environment:
+      CONJUR_APPLIANCE_URL: https://conjur-follower.mycompany.local
       CONJUR_ACCOUNT: demo
       CONJUR_AUTHN_LOGIN: admin
     volumes:
       - .:/src/cli
+      - ./cli_cache/follower:/root
+
+volumes:
+  backups:


### PR DESCRIPTION
The clients (both regular and follower) were broken - 
First error -
```
ERROR: for cluster_follower-client_1  Cannot create container for service follower-client: the working directory '-w /src/cli' is invalid, it needs to be an absolute path
```
Fixed by removing the "-w" flag.

Then, if I was raising the clients using `docker-compose up -d client` it was exiting immediately,
So I added the `sleep` entrypoint. 