### PR TITLE
Add option to use -t flag in cluster demo

### DIFF
--- a/demos/cluster/start
+++ b/demos/cluster/start
@@ -7,12 +7,12 @@ Provisions a Conjur cluster locally, using Docker.
 
 Usage: start [options]
 
-    --auto-failover     Configures the cluster for auto-failover
-    --custom-certs      Installs custom certificates from the "files/certs" folder
-    -h, --help          Shows this help message.
-    --load-data         Loads sample policy along once th cluster
-    --master-key        Encrypts certificates using a master key
-    --tag <conjur-tag>  Starts a cluster with a particular appliance (defaults to 5.0-stable)
+    --auto-failover            Configures the cluster for auto-failover
+    --custom-certs             Installs custom certificates from the "files/certs" folder
+    -h, --help                 Shows this help message.
+    --load-data                Loads sample policy along once th cluster
+    --master-key               Encrypts certificates using a master key
+    -t, --tag <appliance-tag>  Starts a cluster with a particular appliance (defaults to 5.0-stable)
 
 EOF
   exit
@@ -31,7 +31,7 @@ while true ; do
     --load-data ) LOAD_DATA=true ; shift ;;
     --master-key ) MASTER_KEY=true ; shift ;;
     --custom-certs ) CUSTOM_CERTS=true ; shift ;;
-    --tag ) shift ; TAG=$1 ; shift ;;
+    -t | --tag ) shift ; TAG=$1 ; shift ;;
     -h | --help ) print_help ; shift ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac


### PR DESCRIPTION
This PR updates the cluster demo to add the option to run it with the `-t` flag in addition to the `--tag` flag.