### PR TITLE
interactive mode to scripts + turning java installer to single step

### DIFF
--- a/demos/openshift-install/README.md
+++ b/demos/openshift-install/README.md
@@ -24,6 +24,12 @@ OpenShift -     oc v3.11.0+0cbc58b
                 kubernetes v1.11.0+d4cacc0  
                 features: Basic-Auth  
 
+## Important Note:
+The commands below can run in either an interactive mode as well as in a command line mode.
+Interactive mode means that each parameter that was not filled in the command line will be asked to be provided interactively.  
+In interactive mode, some of these parameters have default values defined.
+If the user does not provide an input, the default value is taken.  
+
 ## Commands
 
 1. Building the Java Client:
@@ -32,29 +38,8 @@ OpenShift -     oc v3.11.0+0cbc58b
 $ cd <home-dir>/conjur-intro/demos/java-api-client
 $ ./build.sh
 ```
-  
-2. Installing Conjur and Conjur CLI in OpenShift:
 
-```bash
-$ cd <home-dir>/conjur-intro/demos/openshift-install  
-$ ./installer.sh [--with-config] --ocp-url <ocp-url:port> --project-name <project-name> --account-name <account-name> --authenticator <authenticator>
-```
-
-| Flag | Meaning |
-| ---- | ------- |
-|`--with-config` | Configures the Conjur instance with initial policies |
-|`--ocp-url` | Sets the OpenShift cluster in which Conjur would be installed |
-|`--project-name` | Sets the OpenShift project in which Conjur be installed|
-|`--account-name` | Sets the Conjur account that would be created|
-|`--authenticator` | Sets the authenticator name that would be created|
-
-3. Verify that all pods are up and running by:
-
-```bash
-$ oc get pods
-```
-
-4. Installing and running java client opn Open Shift:
+2. Installing and running ia demo Java client in OpenShift:
 
 ```bash
 $ ./java-client-installer.sh --ocp-url <ocp-url:port> --docker-url <openshift-docker-registry-url> --project-name <project-name> --account-name <account-name> --authenticator <authenticator>
@@ -68,16 +53,42 @@ $ ./java-client-installer.sh --ocp-url <ocp-url:port> --docker-url <openshift-do
 |`--account-name` | Sets the Conjur account that would be used by the demo Java client (should have the same value as above) |
 |`--authenticator` | Sets the authenticator name that would be used by the demo Java client (should have the same value as above) |
 
-5. Verify that all pods are up and running by:
+3. Verify that all pods are up and running by:
 
 ```bash
 $ oc get pods
 ```
 
-6. Checking output of Java client container on pod #4:
+4. Checking output of the demo Java client container in pod #4:
 
 ```bash
 $ oc logs <pod-name> -c my-conjur-java-client  
 ```
 
-It should show that the secret was retrieved properly.
+  It should show that the secret was retrieved properly.
+
+## Remark:
+There is an option to run installer.sh script to install Conjur + Conjur CLI and (optionally) load configuration to it.  
+Commands for it are:  
+
+1. Installing Conjur and Conjur CLI in OpenShift:
+
+```bash
+$ cd <home-dir>/conjur-intro/demos/openshift-install
+$ ./installer.sh --ocp-url <ocp-url:port> --project-name <project-name> --account-name <account-name> --authenticator <authenticator>
+```
+
+| Flag | Meaning |
+| ---- | ------- |
+|`--ocp-url` | Sets the OpenShift cluster in which Conjur would be installed |
+|`--project-name` | Sets the OpenShift project in which Conjur be installed|
+|`--account-name` | Sets the Conjur account that would be created|
+|`--authenticator` | Sets the authenticator name that would be created|
+
+2. Verify that all pods are up and running by:
+
+```bash
+$ oc get pods
+```
+
+

--- a/demos/openshift-install/installer.sh
+++ b/demos/openshift-install/installer.sh
@@ -5,8 +5,8 @@ set -e
 
 OPENSHIFT_URL=
 PROJECT_NAME=
-ACCOUNT_NAME=myaccount
-AUTHENTICATOR=myauthenticator
+ACCOUNT_NAME=
+AUTHENTICATOR=
 
 function validate_app {
   APPNAME=$1
@@ -16,6 +16,32 @@ function validate_app {
     echo "Please install $APPNAME"
     exit 1
   fi
+}
+
+function prepare_input {
+  
+  local PARAM_VALUE=$1
+  local PARAM_NAME=$2
+  local DEFAULT_VALUE=$3
+
+  if [ "$PARAM_VALUE" == "" ]; then
+    if [ -n "$DEFAULT_VALUE" ]; then
+      read -p "Please specify the $PARAM_NAME [$DEFAULT_VALUE]:" PARAM_VALUE
+    else
+      read -p "Please specify the $PARAM_NAME:" PARAM_VALUE
+    fi
+    if [ "$PARAM_VALUE" == "" ]; then
+      if [ -n "$DEFAULT_VALUE" ]; then
+        PARAM_VALUE=$DEFAULT_VALUE
+      else
+        echo "Missing value in $PARAM_NAME - exiting"
+        exit 1
+      fi
+    fi
+  fi
+
+  echo "$PARAM_VALUE"
+
 }
 
 function validate {
@@ -140,18 +166,14 @@ usage()
 
       -h, --help                      Shows this help message
       --ocp-url <url>                 OpenShift URL (mandatory)
-      --with-config                   Basic configuration should be added
       --project-name <project>        OpenShift project name (mandatory)
       --account-name <account>        Conjur account name (mandatory)
       --authenticator <authenticator> Conjur authenticator (mandatory)
 EOF
 }
 
-DO_CONFIG=0
 while [ "$1" != "" ]; do
   case $1 in 
-    --with-config )	DO_CONFIG=1
-                        ;;
     --ocp-url )	        shift
                         OPENSHIFT_URL=$1
                         ;;
@@ -173,23 +195,16 @@ while [ "$1" != "" ]; do
   shift
 done
 
-if [ "$OPENSHIFT_URL" == "" ]; then
-  echo "Missing value in --ocp-url - exiting"
-  exit 1
-fi
-
-if [ "$PROJECT_NAME" == "" ]; then
-  echo "Missing value in --project-name - exiting"
-  exit 1
-fi
-
 validate
+
+OPENSHIFT_URL=$(prepare_input "$OPENSHIFT_URL" "OpenShift URL")
+PROJECT_NAME=$(prepare_input "$PROJECT_NAME" "project name")
+ACCOUNT_NAME=$(prepare_input "$ACCOUNT_NAME" "account name" "default")
+AUTHENTICATOR=$(prepare_input "$AUTHENTICATOR" "authenticator")
 
 install
 
-if [ "$DO_CONFIG" == "1" ]; then
-  config
-fi
+config
 
 #rm -rf conjur-cert.crt
 #rm -rf conjur-cert.pem

--- a/demos/openshift-install/java-client-installer.sh
+++ b/demos/openshift-install/java-client-installer.sh
@@ -5,8 +5,8 @@ set -e
 
 OPENSHIFT_URL=
 PROJECT_NAME=
-ACCOUNT_NAME=myaccount
-AUTHENTICATOR=myauthenticator
+ACCOUNT_NAME=
+AUTHENTICATOR=
 DEPLOYMENT_NAME=conjur-java-api-example
 
 function validate_app {
@@ -28,6 +28,33 @@ function validate {
   validate_app openssl
   validate_app keytool
 }
+
+function prepare_input {
+
+  local PARAM_VALUE=$1
+  local PARAM_NAME=$2
+  local DEFAULT_VALUE=$3
+
+  if [ "$PARAM_VALUE" == "" ]; then
+    if [ -n "$DEFAULT_VALUE" ]; then
+      read -p "Please specify the $PARAM_NAME [$DEFAULT_VALUE]:" PARAM_VALUE
+    else
+      read -p "Please specify the $PARAM_NAME:" PARAM_VALUE
+    fi
+    if [ "$PARAM_VALUE" == "" ]; then
+      if [ -n "$DEFAULT_VALUE" ]; then
+        PARAM_VALUE=$DEFAULT_VALUE
+      else
+        echo "Missing value in $PARAM_NAME - exiting"
+        exit 1
+      fi
+    fi
+  fi
+
+  echo "$PARAM_VALUE"
+
+}
+
 
 function install {
 
@@ -98,17 +125,15 @@ while [ "$1" != "" ]; do
   shift
 done
 
-if [ "$OPENSHIFT_URL" == "" ]; then
-  echo "Missing value in --ocp-url - exiting"
-  exit 1
-fi
-
-if [ "$PROJECT_NAME" == "" ]; then
-  echo "Missing value in --project-name - exiting"
-  exit 1
-fi
-
 validate
+
+OPENSHIFT_URL=$(prepare_input "$OPENSHIFT_URL" "OpenShift URL")
+DOCKER_URL=$(prepare_input "$DOCKER_URL" "OpenShift Docker registry URL")
+PROJECT_NAME=$(prepare_input "$PROJECT_NAME" "project name")
+ACCOUNT_NAME=$(prepare_input "$ACCOUNT_NAME" "account name" "default")
+AUTHENTICATOR=$(prepare_input "$AUTHENTICATOR" "authenticator")
+
+./installer.sh --ocp-url "$OPENSHIFT_URL" --project-name "$PROJECT_NAME" --account-name "$ACCOUNT_NAME" --authenticator "$AUTHENTICATOR"
 
 install
 


### PR DESCRIPTION
1. Adding interactive mode to installer.sh and java-client-installer.sh. 
 It mean that if some parameters are not provided in the script command line, they will be asked interactively to improve user experience.
2. Executing installer.sh as part of java-client-installer.sh. This also improved user experience by turning java installer run to be a single step operation
3. Adding explanation about the above modes of activation to README.md