### PR TITLE
Fix PostgreSQL container initialization.

### DIFF
--- a/demos/certificate-authority/mutual-tls/docker-compose.yml
+++ b/demos/certificate-authority/mutual-tls/docker-compose.yml
@@ -46,6 +46,8 @@ services:
 
   database:
     image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   cli:
     image: cyberark/conjur-cli:5


### PR DESCRIPTION
Hi, I've tried to play with the certificate-authority/mutual-tls demo. The database container initialization doesn't work since the upgrade to the postgres:9.4 image.

This PR fixes the issue by allowing unauthenticated connections to the database.