### PR TITLE
Remove sudo/root requirements to run the demo.

### DIFF
--- a/demos/certificate-authority/mutual-tls/2_create_ca
+++ b/demos/certificate-authority/mutual-tls/2_create_ca
@@ -3,7 +3,7 @@
 # Generate root and intermediate CA certificates
 
 if [ ! -d ca/ca ]; then
-  docker-compose run --rm ca
+  docker-compose run --rm --user $(id -u) ca
 fi
 
 auth_header=$(docker-compose run --rm -T cli -c 'conjur authn authenticate -H') 

--- a/demos/certificate-authority/mutual-tls/3_create_server_cert
+++ b/demos/certificate-authority/mutual-tls/3_create_server_cert
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
 
 rm -rf server/server.crt
-docker-compose run --rm server /server/request_certificate
+docker-compose run --rm --user $(id -u) server /server/request_certificate
 chmod 444 server/server.crt

--- a/demos/certificate-authority/mutual-tls/4_create_client_cert
+++ b/demos/certificate-authority/mutual-tls/4_create_client_cert
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
 
 rm -rf client/client.crt
-docker-compose run --rm client /client/request_certificate
+docker-compose run --rm --user $(id -u) client /client/request_certificate
 chmod 444 client/client.crt

--- a/demos/certificate-authority/mutual-tls/ca/Dockerfile
+++ b/demos/certificate-authority/mutual-tls/ca/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update -y && \
     apt-get install -y openssl
 
 RUN mkdir -p /root
-WORKDIR /root
+WORKDIR /tmp/ca
 
 COPY generate_ca generate_ca
 
-CMD [ "/root/generate_ca" ]
+CMD [ "/tmp/ca/generate_ca" ]

--- a/demos/certificate-authority/mutual-tls/docker-compose.yml
+++ b/demos/certificate-authority/mutual-tls/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   ca:
     build: ./ca
     volumes: 
-      - ./ca:/root
+      - ./ca:/tmp/ca
 
   conjur:
     image: cyberark/conjur


### PR DESCRIPTION
In completion of PR #56 I removed root/sudo requirements to help users run this demo flawlessly.

This PR fixes this issue by adding the `--user $(id -u)` paramater to docker-compose commands and by changing the workdir of the ca image Dockerfile.
