### PR TITLE
fix can't load .rnd into RNG openssl error

### DIFF
--- a/demos/certificate-authority/mutual-tls/client/Dockerfile
+++ b/demos/certificate-authority/mutual-tls/client/Dockerfile
@@ -6,4 +6,7 @@ RUN apt-get update -y && \
       jq \
       curl
 
+# The 2 lines above prevent the `Can't load /root/.rnd into RNG` error
+RUN touch .rnd && chmod 060 .rnd
+
 ADD request_certificate /client/request_certificate


### PR DESCRIPTION
There is an openssl error displayed when lauching https://github.com/conjurdemos/conjur-intro/blob/master/demos/certificate-authority/mutual-tls/4_create_client_cert : ``` Can't load /root/.rnd into RNG ```. 

It is caused by the fact openssl tries to load a .```rnd``` file ```RANDFILE	= $ENV::HOME/.rnd``` as per ```/etc/ssl/openssl.cnf``` configuration file in unbuntu:18.04 Docker image. 

This error does not cause the openssl command to fail but creates unwilling noise in a demo context.