### PR TITLE
Allow custom ports for Conjur leader and follower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ files/haproxy/master/haproxy.cfg
 **/certificates/dap_master/
 **/certificates/intermediate_ca/
 **/certificates/root_ca/
+
+.env

--- a/bin/api
+++ b/bin/api
@@ -1,4 +1,12 @@
 #!/bin/bash -e
 
+# Always work from repo root directory
+cd "$(dirname ${0})/..";
+
+source ./bin/utils.sh
+
+# Make sure .env envvars are available
+dotenv > /dev/null 2>&1 || true
+
 export VERSION='5.0-stable'
 docker-compose run --no-deps --rm api-client bin/api "$@"

--- a/bin/cli
+++ b/bin/cli
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+# Always work from repo root directory
+cd "$(dirname ${0})/..";
+
+source ./bin/utils.sh
+
+# Make sure .env envvars are available
+dotenv > /dev/null 2>&1 || true
+
 function proxy_command {
   cmd="$@"
   docker-compose run --rm -w /src/cli --entrypoint /bin/bash client -c "

--- a/bin/dap
+++ b/bin/dap
@@ -1,4 +1,14 @@
 #!/bin/bash -e
+
+# Always work from repo root directory
+cd "$(dirname ${0})/..";
+
+source ./bin/utils.sh
+
+# Make sure .env envvars are available
+dotenv
+
+CONJUR_MASTER_PORT=${CONJUR_MASTER_PORT:-443}
 _admin_password="MySecretP@ss1"
 
 function _print_help {
@@ -143,7 +153,7 @@ function _perform_promotion {
 function _single_master {
   _start_master
   _configure_master
-  echo "DAP instance available at: 'https://localhost'"
+  echo "DAP instance available at: 'https://localhost:${CONJUR_MASTER_PORT}'"
   echo "Login using with the username/password: 'admin'/'$_admin_password'"
 }
 
@@ -203,9 +213,9 @@ function _disable_autofailover {
 }
 
 function _enable_autofailover {
-  autofailover=$(curl -k https://localhost/info | jq -r .configuration.conjur.cluster_name)
+  autofailover=$(curl -k https://localhost:${CONJUR_MASTER_PORT}/info | jq .configuration.conjur.cluster_name)
 
-  if [ "$autofailover" = 'production' ]; then
+  if [[ $autofailover = 'production' ]]; then
     _run conjur-master-2.mycompany.local "evoke cluster enroll --reenroll --cluster-machine-name conjur-master-2.mycompany.local --master-name conjur-master-1.mycompany.local production"
     _run conjur-master-3.mycompany.local "evoke cluster enroll --reenroll --cluster-machine-name conjur-master-3.mycompany.local --master-name conjur-master-1.mycompany.local production"
   else
@@ -238,7 +248,7 @@ function _stop_and_rename {
 function _upgrade_via_backup_restore {
   upgrade_to="$1"
 
-  autofailover=$(curl -k https://localhost/info | jq -r .configuration.conjur.cluster_name)
+  autofailover=$(curl -k https://localhost:${CONJUR_MASTER_PORT}/info | jq .configuration.conjur.cluster_name)
 
   if [ "$autofailover" = 'production' ]; then
     _disable_autofailover

--- a/bin/dap
+++ b/bin/dap
@@ -6,9 +6,10 @@ cd "$(dirname ${0})/..";
 source ./bin/utils.sh
 
 # Make sure .env envvars are available
-dotenv
+dotenv > /dev/null 2>&1 || true
 
 CONJUR_MASTER_PORT=${CONJUR_MASTER_PORT:-443}
+CONJUR_FOLLOWER_PORT=${CONJUR_FOLLOWER_PORT:-448}
 _admin_password="MySecretP@ss1"
 
 function _print_help {
@@ -130,6 +131,7 @@ function _setup_follower {
     "evoke unpack seed /opt/cyberark/dap/seeds/follower-seed.tar && evoke configure follower"
 
   _start_l7_load_balancer
+  echo "DAP Follower instance available at: 'https://localhost:${CONJUR_FOLLOWER_PORT}'"
 }
 
 #

--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+# Always work from repo root directory
+cd "$(dirname ${0})/..";
+
+source ./bin/utils.sh
+
+# Make sure .env envvars are available
+dotenv > /dev/null 2>&1 || true
+
 container=$(docker ps -aqf "name=master-1.mycompany.local")
 if [ "$1" != "" ]; then
   while [ "$1" != "" ]; do

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function dotenv {
+  local envfile="${1:-.env}"
+
+  # Ensure envfile exists
+  if ! $(ls ${envfile} >/dev/null 2>&1); then
+    echo "${envfile} not found";
+    return 1;
+  fi
+
+  # Export variables first before we source the envfile below
+  local envvars=$(cat ${envfile} | cut -f1 -d=)
+  if [[ -z "${envvars}" ]]; then
+    echo "nothing to source, ${envfile} is empty."
+    return
+  fi
+
+  echo "envvars sourced from ${envfile}:"
+  echo "${envvars}"
+  export $(echo ${envvars})
+
+  # Ensure all env vars values are wrapped in quotation marks before unescaping them,
+  # then source.
+  source <(cat ${envfile} | sed -E 's/\=([^"].*)/="\1"/' | sed -E 's/\="(.*)"$/=\$\(printf \"%b\" "\1"\)/')
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dap_net:
         ipv4_address: 12.16.23.10
     ports:
-      - "443:443"
+      - "${CONJUR_MASTER_PORT:-443}:443"
       - "7000:7000"
     expose:
       - "1999"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       dap_net:
         ipv4_address: 12.16.23.16
     ports:
-      - "449:443"
+      - "${CONJUR_FOLLOWER_PORT:-449}:443"
     expose:
       - "443"
       - "444"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - "5432"
     environment:
       TRUSTED_PROXIES: 123.123.1.1,123.5.1.1
+      CONJUR_AUTHENTICATORS: "${CONJUR_AUTHENTICATORS:-authn}"
     security_opt:
         - "seccomp:unconfined"
     volumes:
@@ -107,6 +108,8 @@ services:
     expose:
       - "443"
       - "444"
+    environment:
+      CONJUR_AUTHENTICATORS: "${CONJUR_AUTHENTICATORS:-authn}"
     security_opt:
         - "seccomp:unconfined"
     volumes:


### PR DESCRIPTION
The work in this branch is used in E2E tests in [cyberark/conjur-authn-k8s-client#362](https://github.com/cyberark/conjur-authn-k8s-client/pull/362).

Allows for supplying environment variables to define:
- custom ports for Conjur leader and follower
- the `CONJUR_AUTHENTICATORS` envvar, in order to whitelist authenticators in Conjur

Based on an old [WIP PR](https://github.com/conjurdemos/conjur-intro/pull/84) allowing a custom port for the Conjur leader.