### PR TITLE
Update java-api-client dependencies and plugins to latest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ files/haproxy/master/haproxy.cfg
 **/certificates/dap_master/
 **/certificates/intermediate_ca/
 **/certificates/root_ca/
+
+# Versions plugin backup file (use git history instead)
+**/pom.xml.versionsBackup

--- a/demos/java-api-client/pom.xml
+++ b/demos/java-api-client/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <conjur-api-version>2.1.0</conjur-api-version>
+        <conjur-api-version>3.0.3</conjur-api-version>
     </properties>
     <groupId>com.cyberark.example</groupId>
     <artifactId>ConjurJavaClient</artifactId>
@@ -13,13 +13,13 @@
         <dependency>
             <groupId>com.cyberark.conjur.api</groupId>
             <artifactId>conjur-api</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.3</version>
         </dependency>
     </dependencies>
     <build><plugins>
           <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <systemPropertyVariables>
                         <CONJUR_ACCOUNT>${env.CONJUR_ACCOUNT}</CONJUR_ACCOUNT>
@@ -64,6 +64,34 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.2.5</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.6</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>    
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.11.0</version>
+            </plugin>
     </plugins></build>
 
 </project>


### PR DESCRIPTION
- Adds the Versions Maven plugin to demos/java-api-client/pom.xml so we can monitor for new versions of plugins and dependencies
- Adds the Maven enforcer plugin to demos/java-api-client/pom.xml so we can monitor the minimum version of Maven required by our plugins
- Updates dependencies and plugins in demos/java-api-client
- Adds pom.xml.versionsBackup to .gitignore to avoid cluttering the repo since we already have history by using git.

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>