### PR TITLE
Use latest base image when building cert-generator

### DIFF
--- a/artifacts/certificate-generator/Dockerfile
+++ b/artifacts/certificate-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.1-alpine3.11 as builder
+FROM golang:alpine as builder
 
 WORKDIR /workdir
 COPY . /workdir


### PR DESCRIPTION
The `cfssl` build was failing because the source was expected a more modern version of golang than our base image used. This PR updates the base image to track with the latest instead. There's no indication more specific pinning is required at this time.