### PR TITLE
Adds ability to set variables from `api` CLI

### DIFF
--- a/artifacts/api-client/api-script
+++ b/artifacts/api-client/api-script
@@ -7,19 +7,20 @@ A tool which uses the DAP API to perform various tasks.
 
 Usage: bin/api [options]
 
-    --against-master                  Runs command against the master (only relevant if command is an authenticate/read action)
-    --authenticate-user               Login using the default username (admin) and password (MySecretP@ss1)
-    --enable-seed-service             Enables Seed Service for Standbys and Followers
-    --fetch-secrets                   Fetches previously set variables (use '--against-master' if only master is available)
-    -h, --help                        Shows this help message
+    --against-master                    Runs command against the master (only relevant if command is an authenticate/read action)
+    --authenticate-user                 Login using the default username (admin) and password (MySecretP@ss1)
+    --enable-seed-service               Enables Seed Service for Standbys and Followers
+    --fetch-secrets                     Fetches previously set variables (use '--against-master' if only master is available)
+    -h, --help                          Shows this help message
     --load-policy
-    --load-sample-policy              Loads a default set of policies to mimic a customer experience
-    --load-sample-policy-and-values   Loads policy and sets variable values (equivalent to running '--load-policy' and '--set-secrets')
-    -p, --password <password>         Password used for authentication (default is 'MySecretP@ss1')
-    --rotate-api-key                  Rotates the authenticated user's API key
-    --set-secrets                     Sets variable values
-    -u, --user <conjur-user>          Username to authenticate with (default is 'admin')
-    --view-roles                      Displays the user's roles
+    --load-sample-policy                Loads a default set of policies to mimic a customer experience
+    --load-sample-policy-and-values     Loads policy and sets variable values (equivalent to running '--load-policy' and '--set-secrets')
+    -p, --password <password>           Password used for authentication (default is 'MySecretP@ss1')
+    --rotate-api-key                    Rotates the authenticated user's API key
+    --set-secrets                       Sets variable values
+    --set-secret-value <path> <value>   Assigns the provided value to the provided variable
+    -u, --user <conjur-user>            Username to authenticate with (default is 'admin')
+    --view-roles                        Displays the user's roles
 
 EOF
   exit
@@ -100,6 +101,12 @@ load_default_policy() {
 
 delete_policy() {
   load_policy 'delete_branch/first-level' 'policy/delete_policy/delete.yml' 'PATCH'
+}
+
+set_secret() {
+  local variable_path="$1"
+  local variable_value="$2"
+  set_variable "$variable_path" "$variable_value"
 }
 
 load_default_values() {
@@ -185,6 +192,7 @@ while true ; do
     --load-sample-policy ) shift ; cmd='load_default_policy' ;;
     --delete-policy ) shift; cmd='delete_policy' ;;
     --set-secrets ) shift ; cmd='load_default_values' ;;
+    --set-secret-value) shift ; cmd="set_secret $1 $2"; shift ; shift ;;
     --against-master ) shift ; URL=$master_url ;;
     --fetch-secrets ) shift ; cmd="retrieve_variables" ;;
     --view-roles ) cmd="view_roles" ; shift ;;


### PR DESCRIPTION
This commit includes functionality to allow variables to be individually set. This allows a user to load custom policy and set variables contained within the custom policy.