### PR TITLE
Fixes: using `docker-compose cp`, nonexistent cert directory

### DIFF
--- a/bin/dap
+++ b/bin/dap
@@ -233,7 +233,7 @@ function _start_l7_load_balancer {
 
 function _configure_master {
   # Copy DH Param
-  docker-compose cp files/dhparam.pem conjur-master-1.mycompany.local:${DHPATH}/dhparam.pem
+  docker cp files/dhparam.pem "$(docker-compose ps -q conjur-master-1.mycompany.local)":${DHPATH}/dhparam.pem
 
   _cmd="evoke configure master"
   _cmd="$_cmd --accept-eula"
@@ -303,7 +303,8 @@ function _perform_promotion {
 function deploy_proxy {
   _set_master_single_node_proxy_config
   # Copy Conjur generated certificates to HAProxy
-  docker-compose cp conjur-master-1.mycompany.local:/opt/conjur/etc/ssl ./system/haproxy/certs
+  mkdir -p ./system/haproxy/certs
+  docker cp "$(docker-compose ps -q conjur-master-1.mycompany.local)":/opt/conjur/etc/ssl/. ./system/haproxy/certs
   docker-compose up -d --no-deps conjur-master.mycompany.local
 }
 


### PR DESCRIPTION
Resolves bugs introduced by #107 that arise when the [Ansible Collection build](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--ansible-conjur-collection/detail/JenkinsCI_Issue/2/pipeline#step-83-log-47) uses this repo to setup Conjur Enterprise.

- It looks like the Jenkins runner has Docker Compose V1 installed. `docker-compose cp` is only supported in V2, so I've converted these into a general form that uses `docker cp`.

- Create `system/haproxy/certs` directory before copying certificates from Leader container to host file system, if it does not yet exist.

[Successful Ansible Collection build](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--ansible-conjur-collection/detail/conjur-intro-test/2/pipeline/) that targets this branch.