### PR TITLE
Adds support for running a load test against a provisioned instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,41 @@ $ docker-compose exec conjur-master-1.mycompany.local ls -a /opt/conjur/possum/
 ```
 
 ## Performance Tests
+
+Conjur Intro includes support for running a simple load test against a running instance.
+
+```sh
+# Start Conjur
+$ bin/dap --provision-master
+
+# Optionally, load 150k secrets
+$ bin/api --load-large-secrets-sample
+
+# Run load test
+$ bin/load-test --name 2023-05-05
 ```
-# Start tests
-$ ./performance_test/start.sh
+
+The above test generates a report in the folder:
+
+`tools/performance-tests/jmeter/jmeter_reports/2023-05-05`
+
+Load is applied using JMeter. The JMeter file is located at:
+
+`tools/performance-tests/Conjur_Performance_Test.jmx`
+
+If changes are required, the easiest way is to use the JMeter UI.
+
+```sh
+# Install JMeter UI
+$ brew install jmeter
+
+# Open UI
+$ jmeter
 ```
-More information can be found [here](./performance_test/README.md#jmeter-performance-test)
+
+Once the JMeter UI is open. Open the above script and make your desired changes. It's
+important to note that the UI does not automatically save changes.  Make sure you save
+before attempting to re-run the script.
 
 ## Contributing
 

--- a/artifacts/api-client/api-script
+++ b/artifacts/api-client/api-script
@@ -12,7 +12,8 @@ Usage: bin/api [options]
     --enable-seed-service               Enables Seed Service for Standbys and Followers
     --fetch-secrets                     Fetches previously set variables (use '--against-master' if only master is available)
     -h, --help                          Shows this help message
-    --load-policy
+    --load-large-secrets-sample         Loads 150k variables with secrets
+    --load-policy <namespace> <policy>  Loads the provided policy into the provided namespace
     --load-sample-policy                Loads a default set of policies to mimic a customer experience
     --load-sample-policy-and-values     Loads policy and sets variable values (equivalent to running '--load-policy' and '--set-secrets')
     -p, --password <password>           Password used for authentication (default is 'MySecretP@ss1')
@@ -26,19 +27,22 @@ EOF
   exit
 }
 
+# General Helper Functions. Any of these functions that communicate with the API should
+# accept an auth token as an input. This greatly increases performance when dealing
+# with multiple API calls.
 retrieve_authentication_token() {
   local user="$1"
   # Allow hosts to be used instead of just users
   user=$(echo "$user" | sed -e "s/\//%2F/g")
   local api_key="$2"
   local url="${3:-$URL}"
-  raw_token="$(curl \
+  token="$(curl \
       --silent \
       --insecure \
+      --header "Accept-Encoding: base64" \
       --request POST \
-      --data $api_key \
+      --data "$api_key" \
       "$url/authn/demo/$user/authenticate")"
-  token=$(echo -n $raw_token | base64 | tr -d '\r\n')
   echo "$token"
 }
 
@@ -49,17 +53,17 @@ authenticate_user() {
   api_key="$(curl \
       --silent \
       --insecure \
-      --user $user:$password \
+      --user "$user:$password" \
       "$url/authn/demo/login")"
-  token=$(retrieve_authentication_token $user $api_key $url)
+  token=$(retrieve_authentication_token "$user" "$api_key" "$url")
   echo "$token"
 }
 
-load_policy() {
+apply_policy() {
   local namespace="$1"
   local policy="$2"
-  local method="${3:-POST}"
-  local token=$(authenticate_user $USER $PASSWORD $master_url)
+  local token="$3"
+  local method="${4:-POST}"
   curl --header "Authorization: Token token=\"$token\"" \
         --write-out "\n" \
         --insecure \
@@ -68,10 +72,20 @@ load_policy() {
      "$master_url/policies/demo/policy/$namespace"
 }
 
+load_policy() {
+  local namespace="$1"
+  local policy="$2"
+  local method="${3:-POST}"
+  local
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+
+  apply_policy "$namespace" "$policy" "$token" "$method"
+}
+
 set_variable() {
   local variable="$1"
   local value="$2"
-  local token=$(authenticate_user $USER $PASSWORD $master_url)
+  local token="$3"
 
   curl --header "Authorization: Token token=\"$token\"" \
         --insecure \
@@ -79,53 +93,41 @@ set_variable() {
         "$master_url/secrets/demo/variable/$variable"
 }
 
-load_default_policy() {
+apply_default_policy() {
   local environments='staging production'
   local numbers='1 2 3 4 5 6'
+  local token="$token"
 
-  load_policy 'root' 'policy/modular/root.yml'
+  apply_policy 'root' 'policy/modular/root.yml' "$token"
 
   for environment in $environments; do
-    load_policy $environment 'policy/modular/apps/applications.yml'
+    apply_policy "$environment" 'policy/modular/apps/applications.yml' "$token"
     for num in $numbers; do
-      load_policy "$environment/my-app-$num" 'policy/modular/apps/generic-application.yml'
-      load_policy "$environment/my-app-$num" 'policy/modular/services/pg-database.yml'
-      load_policy "$environment/my-app-$num" 'policy/modular/pg-entitlement.yml'
+      apply_policy "$environment/my-app-$num" 'policy/modular/apps/generic-application.yml' "$token"
+      apply_policy "$environment/my-app-$num" 'policy/modular/services/pg-database.yml' "$token"
+      apply_policy "$environment/my-app-$num" 'policy/modular/pg-entitlement.yml' "$token"
     done
   done
-
-  load_policy 'root' 'policy/delete_policy/base.yml'
-  load_policy 'delete_branch' 'policy/delete_policy/first_level.yml' 'PUT'
-  load_policy 'delete_branch/first-level' 'policy/delete_policy/second_level.yml'
 }
 
-delete_policy() {
-  load_policy 'delete_branch/first-level' 'policy/delete_policy/delete.yml' 'PATCH'
-}
-
-set_secret() {
-  local variable_path="$1"
-  local variable_value="$2"
-  set_variable "$variable_path" "$variable_value"
-}
-
-load_default_values() {
+apply_default_values() {
+  local token="$1"
   local environments='staging production'
   local numbers='1 2 3 4 5 6'
 
   for environment in $environments; do
     for num in $numbers; do
-      set_variable "$environment/my-app-$num/postgres-database/url" "$environment.my-app-$num.staging.mycompany-postgres.com/my-app"
-      set_variable "$environment/my-app-$num/postgres-database/port" "5432"
-      set_variable "$environment/my-app-$num/postgres-database/username" "my-app-$num"
-      set_variable "$environment/my-app-$num/postgres-database/password" "secret-p@ssword-$environment-my-app-$num"
+      set_variable "$environment/my-app-$num/postgres-database/url" "$environment.my-app-$num.staging.mycompany-postgres.com/my-app" "$token"
+      set_variable "$environment/my-app-$num/postgres-database/port" "5432" "$token"
+      set_variable "$environment/my-app-$num/postgres-database/username" "my-app-$num" "$token"
+      set_variable "$environment/my-app-$num/postgres-database/password" "secret-p@ssword-$environment-my-app-$num" "$token"
     done
   done
 }
 
 fetch_secrets() {
   local variables="$1"
-  local token=$(authenticate_user $USER $PASSWORD $URL)
+  local token="$2"
   curl --header "Authorization: Token token=\"$token\"" \
         --write-out "\n" \
         --insecure \
@@ -133,45 +135,111 @@ fetch_secrets() {
         "$master_url/secrets?variable_ids=$variables"
 }
 
+# The following functions are called directly from the CLI using flags. These functions
+# need to retrieve a token to be passed to the functions interacting directly with
+# the Conjur API
+load_default_policy() {
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  apply_default_policy "$token"
+}
+
+delete_policy() {
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  apply_policy 'delete_branch/first-level' 'policy/delete_policy/delete.yml' "$token" 'PATCH'
+}
+
+set_secret() {
+  local variable_path="$1"
+  local variable_value="$2"
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  set_variable "$variable_path" "$variable_value" "$token"
+}
+
+load_default_values() {
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  apply_default_values "$token"
+}
+
 retrieve_variables() {
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$URL")
   secrets="demo:variable:staging/my-app-1/postgres-database/url,demo:variable:staging/my-app-1/postgres-database/port,demo:variable:staging/my-app-1/postgres-database/username,demo:variable:staging/my-app-1/postgres-database/password"
-  fetch_secrets $secrets
+  fetch_secrets $secrets "$token" | jq .
 }
 
 load_policy_and_set_variables() {
-  load_default_policy
-  load_default_values
-}
-
-view_policy_members() {
-  local token=$(authenticate_user $USER $PASSWORD $URL)
-  curl --header "Authorization: Token token=\"$token\"" \
-        --write-out "\n" \
-        --insecure \
-        --request GET \
-        "$master_url/roles/demo/policy/production?members"
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  apply_default_policy "$token"
+  apply_default_values "$token"
 }
 
 view_roles() {
-  local token=$(authenticate_user $USER $PASSWORD $URL)
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$URL")
   curl --header "Authorization: Token token=\"$token\"" \
         --write-out "\n" \
         --insecure \
         --request GET \
-        "$master_url/resources/demo" | jq .
+        "$URL/resources/demo" | jq .
 }
 
-rotate_api_key() {
+view_policy_members() {
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$URL")
   curl --header "Authorization: Token token=\"$token\"" \
+        --write-out "\n" \
         --insecure \
         --request GET \
-        "$master_url/resources/demo"
+        "$master_url/roles/demo/policy/production?members" | jq .
+}
+
+load_large_policy_and_secrets() {
+  local auth_token
+  local iterations
+  # Each iteration sets 1k secret values
+  iterations=150
+  auth_token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  apply_policy 'root' 'policy/large-policy/root.yml' "$auth_token"
+  for i in $(seq 1 $iterations)
+  do
+    apply_policy "staging-$i" 'policy/large-policy/variables.yml' "$auth_token"
+    # Periodically refresh auth token
+    if [ $((i%10)) = 0 ]; then
+      auth_token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+    fi
+    auth_token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+    for j in $(seq 1 1000)
+    do
+      set_variable "staging-$i/myapp/secret-$j" "super-secret-value!!!" "$auth_token"
+    done
+    echo "loaded $i of $iterations"
+  done
 }
 
 enable_seed_service() {
-  load_policy 'root' 'policy/seed-service/default.yml'
-  load_policy 'conjur' 'policy/seed-service/seed.yml'
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  apply_policy 'root' 'policy/seed-service/default.yml' "$token"
+  apply_policy 'conjur' 'policy/seed-service/seed.yml' "$token"
 }
+
+rotate_api_key() {
+  local user="$1"
+  local token
+  token=$(authenticate_user "$USER" "$PASSWORD" "$master_url")
+  curl --header "Authorization: Token token=\"$token\"" \
+        --write-out "\n" \
+        --insecure \
+        --request PUT \
+        "$master_url/authn/demo/api_key?role=user:$user"
+}
+
+# -- End functions called directly from CLI --
 
 follower_url='http://conjur-follower.mycompany.local'
 master_url='https://conjur-master.mycompany.local'
@@ -185,18 +253,19 @@ while true ; do
     -u | --user ) shift ; USER=$1 ; shift ;;
     -p | --password ) shift ; PASSWORD=$1 ; shift ;;
     --authenticate-user ) shift ; cmd="authenticate_user $USER $PASSWORD" ;;
-    -h | --help ) _print_help ; shift ;;
+    -h | --help ) _print_help ;;
     --patch-policy ) shift ; cmd="load_policy $1 $2 PATCH" ; shift ; shift ;;
     --load-policy ) shift ; cmd="load_policy $1 $2" ; shift ; shift ;;
     --load-sample-policy-and-values ) shift ; cmd="load_policy_and_set_variables" ;;
     --load-sample-policy ) shift ; cmd='load_default_policy' ;;
+    --load-large-secrets-sample ) shift ; cmd='load_large_policy_and_secrets' ;;
     --delete-policy ) shift; cmd='delete_policy' ;;
     --set-secrets ) shift ; cmd='load_default_values' ;;
-    --set-secret-value) shift ; cmd="set_secret $1 $2"; shift ; shift ;;
+    --set-secret-value ) shift ; cmd="set_secret $1 $2"; shift ; shift ;;
     --against-master ) shift ; URL=$master_url ;;
     --fetch-secrets ) shift ; cmd="retrieve_variables" ;;
     --view-roles ) cmd="view_roles" ; shift ;;
-    --rotate-api-key ) cmd="rotate_api_key" ;;
+    --rotate-api-key ) shift ; cmd="rotate_api_key $1" ; shift ;;
     --enable-seed-service ) shift ; cmd='enable_seed_service' ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac

--- a/bin/load-test
+++ b/bin/load-test
@@ -1,0 +1,76 @@
+#!/bin/bash -ex
+
+
+function print_help() {
+  cat << EOF
+NAME
+    Runs a load test against the configured Conjur Enterprise deployment.
+
+SYNOPSIS
+    load [global options]
+
+GLOBAL OPTIONS
+    -h, --help                - Show this message.
+    --headless                - Won't attempt to open the report in browser.
+    --name <folder-name>      - Target folder to export the report to. If the folder exists
+                                the contents will be over-written.
+    --with-follower           - Runs the variable request portion of the test against the
+                                Follower.
+
+EOF
+exit
+}
+
+function run_jmeter_test() {
+  local folder="$1"
+  local local_folder="tools/performance-tests/jmeter/jmeter_reports/$folder"
+
+  rm -rf "$local_folder" || true
+  mkdir -p "$local_folder"
+
+  local jmeter_file='Conjur_Performance_Test'
+  if [ "$USE_FOLLOWER" = 'true' ]; then
+    jmeter_file='Conjur_Performance_Test_With_Follower'
+  fi
+  docker-compose run \
+    --no-deps \
+    --rm \
+    jmeter \
+      jmeter \
+        -Jkey=null \
+        -n \
+        -t "/opt/jmeter_data/$jmeter_file.jmx" \
+        -l "/opt/jmeter_data/jmeter_reports/$folder/Performance_Results.csv" \
+        -e \
+        -o "/opt/jmeter_data/jmeter_reports/$folder"
+}
+
+function open_results_in_browser {
+  local folder="$1"
+  echo "\nReport is available at: 'tools/performance-tests/jmeter/jmeter_reports/$folder'\n"
+  if [ "$HEADLESS" = 'false' ]; then
+    open "tools/performance-tests/jmeter/jmeter_reports/$folder/index.html"
+  fi
+}
+
+function main {
+  local folder="$1"
+  run_jmeter_test "$folder"
+  open_results_in_browser "$folder"
+}
+
+report_folder='default'
+USE_FOLLOWER='false'
+HEADLESS='false'
+
+while true ; do
+  case "$1" in
+    --name ) shift ; report_folder=$1 ; shift ;;
+    --headless ) shift ; HEADLESS="true" ;;
+    --with-follower ) shift ; USE_FOLLOWER="true" ;;
+    -h | --help ) print_help ;;
+     * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
+  esac
+done
+
+main "$report_folder"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,15 @@ services:
     volumes:
       - ./system/configuration/certificates:/src/certificates
 
+  jmeter:
+    build:
+      context: ./tools/performance-tests
+    volumes:
+      - ./tools/performance-tests/jmeter:/opt/jmeter_data
+    networks:
+      dap_net:
+        ipv4_address: 12.16.23.21
+
 volumes:
   seeds:
   follower-certs:

--- a/policy/large-policy/root.yml
+++ b/policy/large-policy/root.yml
@@ -1,0 +1,613 @@
+# Top-level policy file
+- !group team_leads
+- !group security_ops
+
+# Define "staging" namespace, owned by the "team_leads"
+- !policy
+  id: staging
+  owner: !group team_leads
+
+# Define "production" namespace, owned by the "security_ops" team
+- !policy
+  id: production
+  owner: !group security_ops
+
+- !policy
+  id: staging-1
+  owner: !group team_leads
+
+- !policy
+  id: staging-2
+  owner: !group team_leads
+
+- !policy
+  id: staging-3
+  owner: !group team_leads
+
+- !policy
+  id: staging-4
+  owner: !group team_leads
+
+- !policy
+  id: staging-5
+  owner: !group team_leads
+
+- !policy
+  id: staging-6
+  owner: !group team_leads
+
+- !policy
+  id: staging-7
+  owner: !group team_leads
+
+- !policy
+  id: staging-8
+  owner: !group team_leads
+
+- !policy
+  id: staging-9
+  owner: !group team_leads
+
+- !policy
+  id: staging-10
+  owner: !group team_leads
+
+- !policy
+  id: staging-11
+  owner: !group team_leads
+
+- !policy
+  id: staging-12
+  owner: !group team_leads
+
+- !policy
+  id: staging-13
+  owner: !group team_leads
+
+- !policy
+  id: staging-14
+  owner: !group team_leads
+
+- !policy
+  id: staging-15
+  owner: !group team_leads
+
+- !policy
+  id: staging-16
+  owner: !group team_leads
+
+- !policy
+  id: staging-17
+  owner: !group team_leads
+
+- !policy
+  id: staging-18
+  owner: !group team_leads
+
+- !policy
+  id: staging-19
+  owner: !group team_leads
+
+- !policy
+  id: staging-20
+  owner: !group team_leads
+
+- !policy
+  id: staging-21
+  owner: !group team_leads
+
+- !policy
+  id: staging-22
+  owner: !group team_leads
+
+- !policy
+  id: staging-23
+  owner: !group team_leads
+
+- !policy
+  id: staging-24
+  owner: !group team_leads
+
+- !policy
+  id: staging-25
+  owner: !group team_leads
+
+- !policy
+  id: staging-26
+  owner: !group team_leads
+
+- !policy
+  id: staging-27
+  owner: !group team_leads
+
+- !policy
+  id: staging-28
+  owner: !group team_leads
+
+- !policy
+  id: staging-29
+  owner: !group team_leads
+
+- !policy
+  id: staging-30
+  owner: !group team_leads
+
+- !policy
+  id: staging-31
+  owner: !group team_leads
+
+- !policy
+  id: staging-32
+  owner: !group team_leads
+
+- !policy
+  id: staging-33
+  owner: !group team_leads
+
+- !policy
+  id: staging-34
+  owner: !group team_leads
+
+- !policy
+  id: staging-35
+  owner: !group team_leads
+
+- !policy
+  id: staging-36
+  owner: !group team_leads
+
+- !policy
+  id: staging-37
+  owner: !group team_leads
+
+- !policy
+  id: staging-38
+  owner: !group team_leads
+
+- !policy
+  id: staging-39
+  owner: !group team_leads
+
+- !policy
+  id: staging-40
+  owner: !group team_leads
+
+- !policy
+  id: staging-41
+  owner: !group team_leads
+
+- !policy
+  id: staging-42
+  owner: !group team_leads
+
+- !policy
+  id: staging-43
+  owner: !group team_leads
+
+- !policy
+  id: staging-44
+  owner: !group team_leads
+
+- !policy
+  id: staging-45
+  owner: !group team_leads
+
+- !policy
+  id: staging-46
+  owner: !group team_leads
+
+- !policy
+  id: staging-47
+  owner: !group team_leads
+
+- !policy
+  id: staging-48
+  owner: !group team_leads
+
+- !policy
+  id: staging-49
+  owner: !group team_leads
+
+- !policy
+  id: staging-50
+  owner: !group team_leads
+
+- !policy
+  id: staging-51
+  owner: !group team_leads
+
+- !policy
+  id: staging-52
+  owner: !group team_leads
+
+- !policy
+  id: staging-53
+  owner: !group team_leads
+
+- !policy
+  id: staging-54
+  owner: !group team_leads
+
+- !policy
+  id: staging-55
+  owner: !group team_leads
+
+- !policy
+  id: staging-56
+  owner: !group team_leads
+
+- !policy
+  id: staging-57
+  owner: !group team_leads
+
+- !policy
+  id: staging-58
+  owner: !group team_leads
+
+- !policy
+  id: staging-59
+  owner: !group team_leads
+
+- !policy
+  id: staging-60
+  owner: !group team_leads
+
+- !policy
+  id: staging-61
+  owner: !group team_leads
+
+- !policy
+  id: staging-62
+  owner: !group team_leads
+
+- !policy
+  id: staging-63
+  owner: !group team_leads
+
+- !policy
+  id: staging-64
+  owner: !group team_leads
+
+- !policy
+  id: staging-65
+  owner: !group team_leads
+
+- !policy
+  id: staging-66
+  owner: !group team_leads
+
+- !policy
+  id: staging-67
+  owner: !group team_leads
+
+- !policy
+  id: staging-68
+  owner: !group team_leads
+
+- !policy
+  id: staging-69
+  owner: !group team_leads
+
+- !policy
+  id: staging-70
+  owner: !group team_leads
+
+- !policy
+  id: staging-71
+  owner: !group team_leads
+
+- !policy
+  id: staging-72
+  owner: !group team_leads
+
+- !policy
+  id: staging-73
+  owner: !group team_leads
+
+- !policy
+  id: staging-74
+  owner: !group team_leads
+
+- !policy
+  id: staging-75
+  owner: !group team_leads
+
+- !policy
+  id: staging-76
+  owner: !group team_leads
+
+- !policy
+  id: staging-77
+  owner: !group team_leads
+
+- !policy
+  id: staging-78
+  owner: !group team_leads
+
+- !policy
+  id: staging-79
+  owner: !group team_leads
+
+- !policy
+  id: staging-80
+  owner: !group team_leads
+
+- !policy
+  id: staging-81
+  owner: !group team_leads
+
+- !policy
+  id: staging-82
+  owner: !group team_leads
+
+- !policy
+  id: staging-83
+  owner: !group team_leads
+
+- !policy
+  id: staging-84
+  owner: !group team_leads
+
+- !policy
+  id: staging-85
+  owner: !group team_leads
+
+- !policy
+  id: staging-86
+  owner: !group team_leads
+
+- !policy
+  id: staging-87
+  owner: !group team_leads
+
+- !policy
+  id: staging-88
+  owner: !group team_leads
+
+- !policy
+  id: staging-89
+  owner: !group team_leads
+
+- !policy
+  id: staging-90
+  owner: !group team_leads
+
+- !policy
+  id: staging-91
+  owner: !group team_leads
+
+- !policy
+  id: staging-92
+  owner: !group team_leads
+
+- !policy
+  id: staging-93
+  owner: !group team_leads
+
+- !policy
+  id: staging-94
+  owner: !group team_leads
+
+- !policy
+  id: staging-95
+  owner: !group team_leads
+
+- !policy
+  id: staging-96
+  owner: !group team_leads
+
+- !policy
+  id: staging-97
+  owner: !group team_leads
+
+- !policy
+  id: staging-98
+  owner: !group team_leads
+
+- !policy
+  id: staging-99
+  owner: !group team_leads
+
+- !policy
+  id: staging-100
+  owner: !group team_leads
+
+- !policy
+  id: staging-101
+  owner: !group team_leads
+
+- !policy
+  id: staging-102
+  owner: !group team_leads
+
+- !policy
+  id: staging-103
+  owner: !group team_leads
+
+- !policy
+  id: staging-104
+  owner: !group team_leads
+
+- !policy
+  id: staging-105
+  owner: !group team_leads
+
+- !policy
+  id: staging-106
+  owner: !group team_leads
+
+- !policy
+  id: staging-107
+  owner: !group team_leads
+
+- !policy
+  id: staging-108
+  owner: !group team_leads
+
+- !policy
+  id: staging-109
+  owner: !group team_leads
+
+- !policy
+  id: staging-110
+  owner: !group team_leads
+
+- !policy
+  id: staging-111
+  owner: !group team_leads
+
+- !policy
+  id: staging-112
+  owner: !group team_leads
+
+- !policy
+  id: staging-113
+  owner: !group team_leads
+
+- !policy
+  id: staging-114
+  owner: !group team_leads
+
+- !policy
+  id: staging-115
+  owner: !group team_leads
+
+- !policy
+  id: staging-116
+  owner: !group team_leads
+
+- !policy
+  id: staging-117
+  owner: !group team_leads
+
+- !policy
+  id: staging-118
+  owner: !group team_leads
+
+- !policy
+  id: staging-119
+  owner: !group team_leads
+
+- !policy
+  id: staging-120
+  owner: !group team_leads
+
+- !policy
+  id: staging-121
+  owner: !group team_leads
+
+- !policy
+  id: staging-122
+  owner: !group team_leads
+
+- !policy
+  id: staging-123
+  owner: !group team_leads
+
+- !policy
+  id: staging-124
+  owner: !group team_leads
+
+- !policy
+  id: staging-125
+  owner: !group team_leads
+
+- !policy
+  id: staging-126
+  owner: !group team_leads
+
+- !policy
+  id: staging-127
+  owner: !group team_leads
+
+- !policy
+  id: staging-128
+  owner: !group team_leads
+
+- !policy
+  id: staging-129
+  owner: !group team_leads
+
+- !policy
+  id: staging-130
+  owner: !group team_leads
+
+- !policy
+  id: staging-131
+  owner: !group team_leads
+
+- !policy
+  id: staging-132
+  owner: !group team_leads
+
+- !policy
+  id: staging-133
+  owner: !group team_leads
+
+- !policy
+  id: staging-134
+  owner: !group team_leads
+
+- !policy
+  id: staging-135
+  owner: !group team_leads
+
+- !policy
+  id: staging-136
+  owner: !group team_leads
+
+- !policy
+  id: staging-137
+  owner: !group team_leads
+
+- !policy
+  id: staging-138
+  owner: !group team_leads
+
+- !policy
+  id: staging-139
+  owner: !group team_leads
+
+- !policy
+  id: staging-140
+  owner: !group team_leads
+
+- !policy
+  id: staging-141
+  owner: !group team_leads
+
+- !policy
+  id: staging-142
+  owner: !group team_leads
+
+- !policy
+  id: staging-143
+  owner: !group team_leads
+
+- !policy
+  id: staging-144
+  owner: !group team_leads
+
+- !policy
+  id: staging-145
+  owner: !group team_leads
+
+- !policy
+  id: staging-146
+  owner: !group team_leads
+
+- !policy
+  id: staging-147
+  owner: !group team_leads
+
+- !policy
+  id: staging-148
+  owner: !group team_leads
+
+- !policy
+  id: staging-149
+  owner: !group team_leads
+
+- !policy
+  id: staging-150
+  owner: !group team_leads

--- a/policy/large-policy/variables.yml
+++ b/policy/large-policy/variables.yml
@@ -1,0 +1,5051 @@
+- !policy
+  id: myapp
+  body:
+  - &variables
+    - !variable
+      id: database/url
+      annotations:
+        description: Database URL
+    - !variable
+      id: database/port
+      annotations:
+        description: Database port
+    - !variable
+      id: database/username
+      annotations:
+        description: Application database username
+    - !variable
+      id: database/password
+      annotations:
+        description: Application database password
+
+    - !variable
+      id: secret-1
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-2
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-3
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-4
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-5
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-6
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-7
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-8
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-9
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-10
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-11
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-12
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-13
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-14
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-15
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-16
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-17
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-18
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-19
+      annotations:
+        description: Application secret
+
+
+    - !variable
+      id: secret-20
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-21
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-22
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-23
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-24
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-25
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-26
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-27
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-28
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-29
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-30
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-31
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-32
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-33
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-34
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-35
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-36
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-37
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-38
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-39
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-40
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-41
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-42
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-43
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-44
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-45
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-46
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-47
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-48
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-49
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-50
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-51
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-52
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-53
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-54
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-55
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-56
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-57
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-58
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-59
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-60
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-61
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-62
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-63
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-64
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-65
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-66
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-67
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-68
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-69
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-70
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-71
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-72
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-73
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-74
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-75
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-76
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-77
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-78
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-79
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-80
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-81
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-82
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-83
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-84
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-85
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-86
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-87
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-88
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-89
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-90
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-91
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-92
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-93
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-94
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-95
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-96
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-97
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-98
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-99
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-100
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-101
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-102
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-103
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-104
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-105
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-106
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-107
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-108
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-109
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-110
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-111
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-112
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-113
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-114
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-115
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-116
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-117
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-118
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-119
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-120
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-121
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-122
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-123
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-124
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-125
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-126
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-127
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-128
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-129
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-130
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-131
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-132
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-133
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-134
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-135
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-136
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-137
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-138
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-139
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-140
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-141
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-142
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-143
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-144
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-145
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-146
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-147
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-148
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-149
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-150
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-151
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-152
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-153
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-154
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-155
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-156
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-157
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-158
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-159
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-160
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-161
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-162
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-163
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-164
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-165
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-166
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-167
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-168
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-169
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-170
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-171
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-172
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-173
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-174
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-175
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-176
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-177
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-178
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-179
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-180
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-181
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-182
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-183
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-184
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-185
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-186
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-187
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-188
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-189
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-190
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-191
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-192
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-193
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-194
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-195
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-196
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-197
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-198
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-199
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-200
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-201
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-202
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-203
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-204
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-205
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-206
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-207
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-208
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-209
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-210
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-211
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-212
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-213
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-214
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-215
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-216
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-217
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-218
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-219
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-220
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-221
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-222
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-223
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-224
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-225
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-226
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-227
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-228
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-229
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-230
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-231
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-232
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-233
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-234
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-235
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-236
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-237
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-238
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-239
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-240
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-241
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-242
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-243
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-244
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-245
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-246
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-247
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-248
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-249
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-250
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-251
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-252
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-253
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-254
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-255
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-256
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-257
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-258
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-259
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-260
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-261
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-262
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-263
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-264
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-265
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-266
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-267
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-268
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-269
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-270
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-271
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-272
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-273
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-274
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-275
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-276
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-277
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-278
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-279
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-280
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-281
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-282
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-283
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-284
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-285
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-286
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-287
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-288
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-289
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-290
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-291
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-292
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-293
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-294
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-295
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-296
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-297
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-298
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-299
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-300
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-301
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-302
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-303
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-304
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-305
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-306
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-307
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-308
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-309
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-310
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-311
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-312
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-313
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-314
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-315
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-316
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-317
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-318
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-319
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-320
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-321
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-322
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-323
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-324
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-325
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-326
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-327
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-328
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-329
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-330
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-331
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-332
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-333
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-334
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-335
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-336
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-337
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-338
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-339
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-340
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-341
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-342
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-343
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-344
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-345
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-346
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-347
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-348
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-349
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-350
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-351
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-352
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-353
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-354
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-355
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-356
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-357
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-358
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-359
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-360
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-361
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-362
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-363
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-364
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-365
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-366
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-367
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-368
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-369
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-370
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-371
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-372
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-373
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-374
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-375
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-376
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-377
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-378
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-379
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-380
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-381
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-382
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-383
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-384
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-385
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-386
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-387
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-388
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-389
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-390
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-391
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-392
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-393
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-394
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-395
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-396
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-397
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-398
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-399
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-400
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-401
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-402
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-403
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-404
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-405
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-406
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-407
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-408
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-409
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-410
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-411
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-412
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-413
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-414
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-415
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-416
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-417
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-418
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-419
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-420
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-421
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-422
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-423
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-424
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-425
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-426
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-427
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-428
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-429
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-430
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-431
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-432
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-433
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-434
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-435
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-436
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-437
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-438
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-439
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-440
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-441
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-442
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-443
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-444
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-445
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-446
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-447
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-448
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-449
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-450
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-451
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-452
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-453
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-454
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-455
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-456
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-457
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-458
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-459
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-460
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-461
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-462
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-463
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-464
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-465
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-466
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-467
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-468
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-469
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-470
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-471
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-472
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-473
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-474
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-475
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-476
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-477
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-478
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-479
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-480
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-481
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-482
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-483
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-484
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-485
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-486
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-487
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-488
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-489
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-490
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-491
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-492
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-493
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-494
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-495
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-496
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-497
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-498
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-499
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-500
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-501
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-502
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-503
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-504
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-505
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-506
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-507
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-508
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-509
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-510
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-511
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-512
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-513
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-514
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-515
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-516
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-517
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-518
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-519
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-520
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-521
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-522
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-523
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-524
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-525
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-526
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-527
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-528
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-529
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-530
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-531
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-532
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-533
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-534
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-535
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-536
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-537
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-538
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-539
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-540
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-541
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-542
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-543
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-544
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-545
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-546
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-547
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-548
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-549
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-550
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-551
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-552
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-553
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-554
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-555
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-556
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-557
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-558
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-559
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-560
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-561
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-562
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-563
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-564
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-565
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-566
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-567
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-568
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-569
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-570
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-571
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-572
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-573
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-574
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-575
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-576
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-577
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-578
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-579
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-580
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-581
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-582
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-583
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-584
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-585
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-586
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-587
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-588
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-589
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-590
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-591
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-592
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-593
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-594
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-595
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-596
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-597
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-598
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-599
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-600
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-601
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-602
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-603
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-604
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-605
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-606
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-607
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-608
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-609
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-610
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-611
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-612
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-613
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-614
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-615
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-616
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-617
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-618
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-619
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-620
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-621
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-622
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-623
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-624
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-625
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-626
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-627
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-628
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-629
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-630
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-631
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-632
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-633
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-634
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-635
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-636
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-637
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-638
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-639
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-640
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-641
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-642
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-643
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-644
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-645
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-646
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-647
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-648
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-649
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-650
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-651
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-652
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-653
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-654
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-655
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-656
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-657
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-658
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-659
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-660
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-661
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-662
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-663
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-664
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-665
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-666
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-667
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-668
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-669
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-670
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-671
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-672
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-673
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-674
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-675
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-676
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-677
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-678
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-679
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-680
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-681
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-682
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-683
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-684
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-685
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-686
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-687
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-688
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-689
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-690
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-691
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-692
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-693
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-694
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-695
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-696
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-697
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-698
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-699
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-700
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-701
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-702
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-703
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-704
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-705
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-706
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-707
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-708
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-709
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-710
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-711
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-712
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-713
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-714
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-715
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-716
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-717
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-718
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-719
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-720
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-721
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-722
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-723
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-724
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-725
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-726
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-727
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-728
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-729
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-730
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-731
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-732
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-733
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-734
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-735
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-736
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-737
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-738
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-739
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-740
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-741
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-742
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-743
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-744
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-745
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-746
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-747
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-748
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-749
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-750
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-751
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-752
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-753
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-754
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-755
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-756
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-757
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-758
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-759
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-760
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-761
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-762
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-763
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-764
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-765
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-766
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-767
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-768
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-769
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-770
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-771
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-772
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-773
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-774
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-775
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-776
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-777
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-778
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-779
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-780
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-781
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-782
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-783
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-784
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-785
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-786
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-787
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-788
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-789
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-790
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-791
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-792
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-793
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-794
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-795
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-796
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-797
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-798
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-799
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-800
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-801
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-802
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-803
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-804
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-805
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-806
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-807
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-808
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-809
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-810
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-811
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-812
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-813
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-814
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-815
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-816
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-817
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-818
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-819
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-820
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-821
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-822
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-823
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-824
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-825
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-826
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-827
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-828
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-829
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-830
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-831
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-832
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-833
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-834
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-835
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-836
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-837
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-838
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-839
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-840
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-841
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-842
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-843
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-844
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-845
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-846
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-847
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-848
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-849
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-850
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-851
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-852
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-853
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-854
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-855
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-856
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-857
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-858
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-859
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-860
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-861
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-862
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-863
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-864
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-865
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-866
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-867
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-868
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-869
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-870
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-871
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-872
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-873
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-874
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-875
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-876
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-877
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-878
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-879
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-880
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-881
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-882
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-883
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-884
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-885
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-886
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-887
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-888
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-889
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-890
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-891
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-892
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-893
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-894
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-895
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-896
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-897
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-898
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-899
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-900
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-901
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-902
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-903
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-904
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-905
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-906
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-907
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-908
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-909
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-910
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-911
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-912
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-913
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-914
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-915
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-916
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-917
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-918
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-919
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-920
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-921
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-922
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-923
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-924
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-925
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-926
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-927
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-928
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-929
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-930
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-931
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-932
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-933
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-934
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-935
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-936
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-937
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-938
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-939
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-940
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-941
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-942
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-943
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-944
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-945
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-946
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-947
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-948
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-949
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-950
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-951
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-952
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-953
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-954
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-955
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-956
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-957
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-958
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-959
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-960
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-961
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-962
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-963
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-964
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-965
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-966
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-967
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-968
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-969
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-970
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-971
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-972
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-973
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-974
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-975
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-976
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-977
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-978
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-979
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-980
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-981
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-982
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-983
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-984
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-985
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-986
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-987
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-988
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-989
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-990
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-991
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-992
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-993
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-994
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-995
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-996
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-997
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-998
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-999
+      annotations:
+        description: Application secret
+
+    - !variable
+      id: secret-1000
+      annotations:
+        description: Application secret
+
+  - !layer
+
+  - !host-factory
+    layer: [ !layer ]
+
+  - !group secrets-users
+  - !group secrets-managers
+
+  # secrets-users can read and execute
+  - !permit
+    resource: *variables
+    privileges: [ read, execute ]
+    role: !group secrets-users
+
+  # secrets-managers can update (and read and execute, via role grant)
+  - !permit
+    resource: *variables
+    privileges: [ update ]
+    role: !group secrets-managers
+
+  # secrets-managers has role secrets-users
+  - !grant
+    member: !group secrets-managers
+    role: !group secrets-users
+
+  # Application layer has the secrets-users role
+  - !grant
+    member: !layer
+    role: !group secrets-users

--- a/tools/performance-tests/jmeter/Conjur_Performance_Test.jmx
+++ b/tools/performance-tests/jmeter/Conjur_Performance_Test.jmx
@@ -1,0 +1,2319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="DAP_Performance_Test" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="host" elementType="Argument">
+            <stringProp name="Argument.name">host</stringProp>
+            <stringProp name="Argument.value">conjur</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Change this value to jmeter.apache.org</stringProp>
+          </elementProp>
+          <elementProp name="safecount" elementType="Argument">
+            <stringProp name="Argument.name">safecount</stringProp>
+            <stringProp name="Argument.value">500</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="threadCount" elementType="Argument">
+            <stringProp name="Argument.name">threadCount</stringProp>
+            <stringProp name="Argument.value">8</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="server" elementType="Argument">
+            <stringProp name="Argument.name">server</stringProp>
+            <stringProp name="Argument.value">conjur-master.mycompany.local</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="conjurAccount" elementType="Argument">
+            <stringProp name="Argument.name">conjurAccount</stringProp>
+            <stringProp name="Argument.value">demo</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="password" elementType="Argument">
+            <stringProp name="Argument.name">password</stringProp>
+            <stringProp name="Argument.value">Basic YWRtaW46TXlTZWNyZXRQQHNzMQ==</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="key" elementType="Argument">
+            <stringProp name="Argument.name">key</stringProp>
+            <stringProp name="Argument.value">null</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </SetupThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Login" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">true</boolProp>
+                <stringProp name="Argument.value"></stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/login</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">${password}</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;response&quot;, prev.getResponseDataAsString());
+</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${response}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/admin/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+log.info(&quot;response: &quot; + vars.getObject(&quot;response&quot;));
+log.info(&quot;class: &quot; + vars.getObject(&quot;response&quot;).getClass());
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="update root policy: users.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !group security_ops&#xd;
+- !group team_leads&#xd;
+- !group developers&#xd;
+&#xd;
+- !user&#xd;
+  id: jason.vanderhoof&#xd;
+  annotations:&#xd;
+    first_name: Jason&#xd;
+    last_name: Vanderhoof&#xd;
+    email: jason.vanderhoof@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: marcel.calisto&#xd;
+  annotations:&#xd;
+    first_name: Marcel&#xd;
+    last_name: Calisto&#xd;
+    email: marcel.calisto@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: ernest.alvin&#xd;
+  annotations:&#xd;
+    first_name: Ernest&#xd;
+    last_name: Alvin&#xd;
+    email: ernest.alvin@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: victoria.nandita&#xd;
+  annotations:&#xd;
+    first_name: Victoria&#xd;
+    last_name: Nandita&#xd;
+    email: victoria.nandita@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: sophie.madelon&#xd;
+  annotations:&#xd;
+    first_name: Sophie&#xd;
+    last_name: Madelon&#xd;
+    email: sophie.madelon@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: terrance.blake&#xd;
+  annotations:&#xd;
+    first_name: Terrance&#xd;
+    last_name: Blake&#xd;
+    email: terrance.blake@cyberark.com&#xd;
+&#xd;
+- !grant&#xd;
+  role: !group developers&#xd;
+  members:&#xd;
+    - !user marcel.calisto&#xd;
+    - !user ernest.alvin&#xd;
+    - !user sophie.madelon&#xd;
+&#xd;
+- !grant&#xd;
+  role: !group team_leads&#xd;
+  members:&#xd;
+    - !user jason.vanderhoof&#xd;
+    - !user victoria.nandita&#xd;
+&#xd;
+- !grant&#xd;
+  role: !group security_ops&#xd;
+  members:&#xd;
+    - !user terrance.blake&#xd;
+&#xd;
+# Grant the less-powerful groups to the more-powerful groups&#xd;
+- !grant&#xd;
+  member: !group team_leads&#xd;
+  role: !group developers&#xd;
+&#xd;
+- !grant&#xd;
+  member: !group security_ops&#xd;
+  role: !group team_leads</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.26213</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append root policy: policy.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value"># Top-level policy file&#xd;
+- !group team_leads&#xd;
+- !group security_ops&#xd;
+&#xd;
+# Define &quot;staging&quot; namespace, owned by the &quot;team_leads&quot;&#xd;
+- !policy&#xd;
+  id: staging&#xd;
+  owner: !group team_leads&#xd;
+&#xd;
+# Define &quot;production&quot; namespace, owned by the &quot;security_ops&quot; team&#xd;
+- !policy&#xd;
+  id: production&#xd;
+  owner: !group security_ops&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append staging policy: myapp.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !policy&#xd;
+  id: myapp&#xd;
+  body:&#xd;
+  - &amp;variables&#xd;
+    - !variable&#xd;
+      id: database/url&#xd;
+      annotations:&#xd;
+        description: Database URL&#xd;
+    - !variable&#xd;
+      id: database/port&#xd;
+      annotations:&#xd;
+        description: Database port&#xd;
+    - !variable&#xd;
+      id: database/username&#xd;
+      annotations:&#xd;
+        description: Application database username&#xd;
+    - !variable&#xd;
+      id: database/password&#xd;
+      annotations:&#xd;
+        description: Application database password&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-1&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-2&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-3&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-4&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-5&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-6&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-7&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-8&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-9&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-10&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-11&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-12&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-13&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-14&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-15&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-16&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-17&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-18&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-19&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-20&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-21&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-22&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-23&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-24&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-25&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-26&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-27&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-28&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-29&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-30&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-31&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-32&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-33&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-34&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-35&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-36&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-37&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-38&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-39&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-40&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-41&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-42&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-43&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-44&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-45&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-46&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-47&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-48&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-49&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-50&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-51&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-52&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-53&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-54&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-55&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-56&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-57&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-58&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-59&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-60&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-61&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-62&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-63&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-64&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-65&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-66&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-67&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-68&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-69&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-70&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-71&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-72&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-73&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-74&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-75&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-76&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-77&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-78&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-79&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-80&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-81&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-82&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-83&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-84&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-85&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-86&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-87&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-88&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-89&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-90&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-91&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-92&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-93&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-94&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-95&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-96&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-97&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-98&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-99&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+  - !layer&#xd;
+&#xd;
+  - !host-factory&#xd;
+    layer: [ !layer ]&#xd;
+&#xd;
+  - !group secrets-users&#xd;
+  - !group secrets-managers&#xd;
+&#xd;
+  # secrets-users can read and execute&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ read, execute ]&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # secrets-managers can update (and read and execute, via role grant)&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ update ]&#xd;
+    role: !group secrets-managers&#xd;
+&#xd;
+  # secrets-managers has role secrets-users&#xd;
+  - !grant&#xd;
+    member: !group secrets-managers&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # Application layer has the secrets-users role&#xd;
+  - !grant&#xd;
+    member: !layer&#xd;
+    role: !group secrets-users</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/staging</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append production policy: myapp.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !policy&#xd;
+  id: myapp&#xd;
+  body:&#xd;
+  - &amp;variables&#xd;
+    - !variable&#xd;
+      id: database/url&#xd;
+      annotations:&#xd;
+        description: Database URL&#xd;
+    - !variable&#xd;
+      id: database/port&#xd;
+      annotations:&#xd;
+        description: Database port&#xd;
+    - !variable&#xd;
+      id: database/username&#xd;
+      annotations:&#xd;
+        description: Application database username&#xd;
+    - !variable&#xd;
+      id: database/password&#xd;
+      annotations:&#xd;
+        description: Application database password&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-1&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-2&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-3&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-4&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-5&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-6&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-7&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-8&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-9&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-10&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-11&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-12&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-13&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-14&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-15&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-16&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-17&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-18&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-19&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-20&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-21&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-22&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-23&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-24&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-25&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-26&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-27&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-28&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-29&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-30&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-31&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-32&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-33&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-34&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-35&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-36&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-37&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-38&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-39&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-40&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-41&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-42&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-43&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-44&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-45&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-46&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-47&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-48&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-49&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-50&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-51&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-52&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-53&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-54&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-55&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-56&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-57&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-58&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-59&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-60&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-61&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-62&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-63&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-64&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-65&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-66&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-67&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-68&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-69&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-70&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-71&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-72&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-73&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-74&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-75&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-76&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-77&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-78&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-79&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-80&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-81&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-82&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-83&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-84&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-85&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-86&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-87&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-88&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-89&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-90&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-91&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-92&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-93&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-94&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-95&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-96&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-97&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-98&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-99&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+  - !layer&#xd;
+&#xd;
+  - !host-factory&#xd;
+    layer: [ !layer ]&#xd;
+&#xd;
+  - !group secrets-users&#xd;
+  - !group secrets-managers&#xd;
+&#xd;
+  # secrets-users can read and execute&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ read, execute ]&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # secrets-managers can update (and read and execute, via role grant)&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ update ]&#xd;
+    role: !group secrets-managers&#xd;
+&#xd;
+  # secrets-managers has role secrets-users&#xd;
+  - !grant&#xd;
+    member: !group secrets-managers&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # Application layer has the secrets-users role&#xd;
+  - !grant&#xd;
+    member: !layer&#xd;
+    role: !group secrets-users</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/production</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append root policy: application_grants.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value"># Grant the team_leads permission to read+write the &quot;myapp&quot; variables in production&#xd;
+- !grant&#xd;
+  member: !group developers&#xd;
+  role: !group staging/myapp/secrets-users</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append root policy: hosts.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !host test-host-1&#xd;
+&#xd;
+- !grant&#xd;
+  role: !layer production/myapp&#xd;
+  member: !host test-host-1</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor" enabled="true">
+            <stringProp name="JSONPostProcessor.referenceNames">key</stringProp>
+            <stringProp name="JSONPostProcessor.jsonPathExprs">$.created_roles.demo:host:test-host-1.api_key</stringProp>
+            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+          </JSONPostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set Property key" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">import org.apache.jmeter.util.JMeterUtils;
+
+if(vars.getObject(&quot;key&quot;)){
+	JMeterUtils.setProperty(&quot;key&quot;, vars.getObject(&quot;key&quot;));
+	log.info(&quot;Set key property: &quot; + vars.getObject(&quot;key&quot;));
+}</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Rotate Host API Key" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/api_key?role=host:test-host-1</stringProp>
+          <stringProp name="HTTPSampler.method">PUT</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="script">import org.apache.jmeter.util.JMeterUtils;
+
+//vars.put(&quot;key&quot;, );
+JMeterUtils.setProperty(&quot;key&quot;,prev.getResponseDataAsString());</stringProp>
+          </BeanShellPostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/username" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">alice</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/username</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/password" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">wonderland</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/password</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/url" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">https://oxfordshire.wonder.com</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/url</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/port" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">1951</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/port</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/port" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">1951</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/port</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 1" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">2</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">20</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safes secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${server}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Individually Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${server}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets/demo/variable/production/myapp/database/username</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 2 - Bulk  Retrieval " enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">2</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">20</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${server}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safes secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${server}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Batch Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${server}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets?variable_ids=demo:variable:production%2Fmyapp%2Fdatabase%2Fusername,demo:variable:production%2Fmyapp%2Fdatabase%2Fpassword,demo:variable:production%2Fmyapp%2Fdatabase%2Fport,demo:variable:production%2Fmyapp%2Fdatabase%2Furl</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ResultCollector guiclass="StatGraphVisualizer" testclass="ResultCollector" testname="Aggregate Graph" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename">/Users/hartzi/Desktop/DAP_Performance_Results.jtl</stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename">/Users/hartzi/Desktop/DAP_Performance_Results.jtl</stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>true</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/tools/performance-tests/jmeter/Conjur_Performance_Test_With_Follower.jmx
+++ b/tools/performance-tests/jmeter/Conjur_Performance_Test_With_Follower.jmx
@@ -1,0 +1,3542 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="DAP_Performance_Test" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="host" elementType="Argument">
+            <stringProp name="Argument.name">host</stringProp>
+            <stringProp name="Argument.value">conjur</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Change this value to jmeter.apache.org</stringProp>
+          </elementProp>
+          <elementProp name="safecount" elementType="Argument">
+            <stringProp name="Argument.name">safecount</stringProp>
+            <stringProp name="Argument.value">500</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="threadCount" elementType="Argument">
+            <stringProp name="Argument.name">threadCount</stringProp>
+            <stringProp name="Argument.value">8</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="writeServer" elementType="Argument">
+            <stringProp name="Argument.name">writeServer</stringProp>
+            <stringProp name="Argument.value">conjur-master.mycompany.local</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="conjurAccount" elementType="Argument">
+            <stringProp name="Argument.name">conjurAccount</stringProp>
+            <stringProp name="Argument.value">demo</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="password" elementType="Argument">
+            <stringProp name="Argument.name">password</stringProp>
+            <stringProp name="Argument.value">Basic YWRtaW46TXlTZWNyZXRQQHNzMQ==</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="key" elementType="Argument">
+            <stringProp name="Argument.name">key</stringProp>
+            <stringProp name="Argument.value">null</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="readServer" elementType="Argument">
+            <stringProp name="Argument.name">readServer</stringProp>
+            <stringProp name="Argument.value">conjur-follower.mycompany.local</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </SetupThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Login" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">true</boolProp>
+                <stringProp name="Argument.value"></stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/login</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">${password}</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;response&quot;, prev.getResponseDataAsString());
+</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${response}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/admin/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+log.info(&quot;response: &quot; + vars.getObject(&quot;response&quot;));
+log.info(&quot;class: &quot; + vars.getObject(&quot;response&quot;).getClass());
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="update root policy: users.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !group security_ops&#xd;
+- !group team_leads&#xd;
+- !group developers&#xd;
+&#xd;
+- !user&#xd;
+  id: jason.vanderhoof&#xd;
+  annotations:&#xd;
+    first_name: Jason&#xd;
+    last_name: Vanderhoof&#xd;
+    email: jason.vanderhoof@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: marcel.calisto&#xd;
+  annotations:&#xd;
+    first_name: Marcel&#xd;
+    last_name: Calisto&#xd;
+    email: marcel.calisto@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: ernest.alvin&#xd;
+  annotations:&#xd;
+    first_name: Ernest&#xd;
+    last_name: Alvin&#xd;
+    email: ernest.alvin@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: victoria.nandita&#xd;
+  annotations:&#xd;
+    first_name: Victoria&#xd;
+    last_name: Nandita&#xd;
+    email: victoria.nandita@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: sophie.madelon&#xd;
+  annotations:&#xd;
+    first_name: Sophie&#xd;
+    last_name: Madelon&#xd;
+    email: sophie.madelon@cyberark.com&#xd;
+&#xd;
+- !user&#xd;
+  id: terrance.blake&#xd;
+  annotations:&#xd;
+    first_name: Terrance&#xd;
+    last_name: Blake&#xd;
+    email: terrance.blake@cyberark.com&#xd;
+&#xd;
+- !grant&#xd;
+  role: !group developers&#xd;
+  members:&#xd;
+    - !user marcel.calisto&#xd;
+    - !user ernest.alvin&#xd;
+    - !user sophie.madelon&#xd;
+&#xd;
+- !grant&#xd;
+  role: !group team_leads&#xd;
+  members:&#xd;
+    - !user jason.vanderhoof&#xd;
+    - !user victoria.nandita&#xd;
+&#xd;
+- !grant&#xd;
+  role: !group security_ops&#xd;
+  members:&#xd;
+    - !user terrance.blake&#xd;
+&#xd;
+# Grant the less-powerful groups to the more-powerful groups&#xd;
+- !grant&#xd;
+  member: !group team_leads&#xd;
+  role: !group developers&#xd;
+&#xd;
+- !grant&#xd;
+  member: !group security_ops&#xd;
+  role: !group team_leads</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.26213</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append root policy: policy.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value"># Top-level policy file&#xd;
+- !group team_leads&#xd;
+- !group security_ops&#xd;
+&#xd;
+# Define &quot;staging&quot; namespace, owned by the &quot;team_leads&quot;&#xd;
+- !policy&#xd;
+  id: staging&#xd;
+  owner: !group team_leads&#xd;
+&#xd;
+# Define &quot;production&quot; namespace, owned by the &quot;security_ops&quot; team&#xd;
+- !policy&#xd;
+  id: production&#xd;
+  owner: !group security_ops&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append staging policy: myapp.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !policy&#xd;
+  id: myapp&#xd;
+  body:&#xd;
+  - &amp;variables&#xd;
+    - !variable&#xd;
+      id: database/url&#xd;
+      annotations:&#xd;
+        description: Database URL&#xd;
+    - !variable&#xd;
+      id: database/port&#xd;
+      annotations:&#xd;
+        description: Database port&#xd;
+    - !variable&#xd;
+      id: database/username&#xd;
+      annotations:&#xd;
+        description: Application database username&#xd;
+    - !variable&#xd;
+      id: database/password&#xd;
+      annotations:&#xd;
+        description: Application database password&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-1&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-2&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-3&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-4&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-5&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-6&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-7&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-8&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-9&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-10&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-11&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-12&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-13&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-14&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-15&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-16&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-17&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-18&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-19&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-20&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-21&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-22&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-23&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-24&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-25&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-26&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-27&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-28&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-29&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-30&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-31&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-32&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-33&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-34&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-35&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-36&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-37&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-38&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-39&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-40&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-41&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-42&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-43&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-44&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-45&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-46&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-47&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-48&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-49&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-50&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-51&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-52&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-53&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-54&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-55&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-56&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-57&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-58&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-59&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-60&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-61&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-62&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-63&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-64&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-65&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-66&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-67&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-68&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-69&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-70&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-71&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-72&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-73&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-74&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-75&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-76&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-77&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-78&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-79&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-80&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-81&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-82&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-83&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-84&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-85&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-86&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-87&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-88&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-89&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-90&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-91&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-92&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-93&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-94&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-95&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-96&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-97&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-98&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-99&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+  - !layer&#xd;
+&#xd;
+  - !host-factory&#xd;
+    layer: [ !layer ]&#xd;
+&#xd;
+  - !group secrets-users&#xd;
+  - !group secrets-managers&#xd;
+&#xd;
+  # secrets-users can read and execute&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ read, execute ]&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # secrets-managers can update (and read and execute, via role grant)&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ update ]&#xd;
+    role: !group secrets-managers&#xd;
+&#xd;
+  # secrets-managers has role secrets-users&#xd;
+  - !grant&#xd;
+    member: !group secrets-managers&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # Application layer has the secrets-users role&#xd;
+  - !grant&#xd;
+    member: !layer&#xd;
+    role: !group secrets-users</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/staging</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append production policy: myapp.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !policy&#xd;
+  id: myapp&#xd;
+  body:&#xd;
+  - &amp;variables&#xd;
+    - !variable&#xd;
+      id: database/url&#xd;
+      annotations:&#xd;
+        description: Database URL&#xd;
+    - !variable&#xd;
+      id: database/port&#xd;
+      annotations:&#xd;
+        description: Database port&#xd;
+    - !variable&#xd;
+      id: database/username&#xd;
+      annotations:&#xd;
+        description: Application database username&#xd;
+    - !variable&#xd;
+      id: database/password&#xd;
+      annotations:&#xd;
+        description: Application database password&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-1&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-2&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-3&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-4&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-5&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-6&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-7&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-8&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-9&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-10&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-11&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-12&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-13&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-14&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-15&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-16&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-17&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-18&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-19&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-20&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-21&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-22&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-23&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-24&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-25&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-26&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-27&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-28&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-29&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-30&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-31&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-32&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-33&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-34&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-35&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-36&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-37&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-38&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-39&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-40&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-41&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-42&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-43&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-44&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-45&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-46&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-47&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-48&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-49&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-50&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-51&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-52&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-53&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-54&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-55&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-56&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-57&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-58&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-59&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-60&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-61&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-62&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-63&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-64&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-65&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-66&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-67&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-68&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-69&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-70&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-71&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-72&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-73&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-74&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-75&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-76&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-77&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-78&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-79&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-80&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-81&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-82&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-83&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-84&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-85&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-86&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-87&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-88&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-89&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-90&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-91&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-92&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-93&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-94&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-95&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-96&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-97&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-98&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+    - !variable&#xd;
+      id: secret-99&#xd;
+      annotations:&#xd;
+        description: Application secret&#xd;
+&#xd;
+  - !layer&#xd;
+&#xd;
+  - !host-factory&#xd;
+    layer: [ !layer ]&#xd;
+&#xd;
+  - !group secrets-users&#xd;
+  - !group secrets-managers&#xd;
+&#xd;
+  # secrets-users can read and execute&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ read, execute ]&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # secrets-managers can update (and read and execute, via role grant)&#xd;
+  - !permit&#xd;
+    resource: *variables&#xd;
+    privileges: [ update ]&#xd;
+    role: !group secrets-managers&#xd;
+&#xd;
+  # secrets-managers has role secrets-users&#xd;
+  - !grant&#xd;
+    member: !group secrets-managers&#xd;
+    role: !group secrets-users&#xd;
+&#xd;
+  # Application layer has the secrets-users role&#xd;
+  - !grant&#xd;
+    member: !layer&#xd;
+    role: !group secrets-users</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/production</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append root policy: application_grants.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value"># Grant the team_leads permission to read+write the &quot;myapp&quot; variables in production&#xd;
+- !grant&#xd;
+  member: !group developers&#xd;
+  role: !group staging/myapp/secrets-users</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Append root policy: hosts.yml" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">- !host test-host-1&#xd;
+&#xd;
+- !grant&#xd;
+  role: !layer production/myapp&#xd;
+  member: !host test-host-1</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/policies/${conjurAccount}/policy/root</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor" enabled="true">
+            <stringProp name="JSONPostProcessor.referenceNames">key</stringProp>
+            <stringProp name="JSONPostProcessor.jsonPathExprs">$.created_roles.demo:host:test-host-1.api_key</stringProp>
+            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+          </JSONPostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set Property key" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">import org.apache.jmeter.util.JMeterUtils;
+
+if(vars.getObject(&quot;key&quot;)){
+	JMeterUtils.setProperty(&quot;key&quot;, vars.getObject(&quot;key&quot;));
+	log.info(&quot;Set key property: &quot; + vars.getObject(&quot;key&quot;));
+}</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Rotate Host API Key" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/api_key?role=host:test-host-1</stringProp>
+          <stringProp name="HTTPSampler.method">PUT</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="script">import org.apache.jmeter.util.JMeterUtils;
+
+//vars.put(&quot;key&quot;, );
+JMeterUtils.setProperty(&quot;key&quot;,prev.getResponseDataAsString());</stringProp>
+          </BeanShellPostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/username" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">alice</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/username</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/password" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">wonderland</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/password</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/url" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">https://oxfordshire.wonder.com</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/url</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/port" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">1951</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/port</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Set Secret: production/myapp/database/port" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">1951</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${writeServer}</stringProp>
+          <stringProp name="HTTPSampler.port">443</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/secrets/${conjurAccount}/variable/production/myapp/database/port</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Authorization" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 1 - Individual Secret Lookup" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">5</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">5</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safes secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Individually Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets/demo/variable/production/myapp/database/username</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 2" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">5</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">5</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safs secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Batch Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets?variable_ids=demo:variable:production%2Fmyapp%2Fdatabase%2Fusername</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 3 - Individual Secret Lookup" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">5</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">5</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safs secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Individually Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets/demo/variable/production/myapp/database/username</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 4" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">5</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">5</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safs secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Batch Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets?variable_ids=demo:variable:production%2Fmyapp%2Fdatabase%2Fusername</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 5 - Individual Secret Lookup" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safs secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Individually Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets/demo/variable/production/myapp/database/username</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 6" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safs secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Batch Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets?variable_ids=demo:variable:production%2Fmyapp%2Fdatabase%2Fusername</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 7 - Individual Secret Lookup" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safs secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Individually Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets/demo/variable/production/myapp/database/username</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group 8" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set BaseDate" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <UserParameters guiclass="UserParametersGui" testclass="UserParameters" testname="User Parameters" enabled="true">
+          <collectionProp name="UserParameters.names">
+            <stringProp name="-172355018">threadGroupMultiplier</stringProp>
+          </collectionProp>
+          <collectionProp name="UserParameters.thread_values">
+            <collectionProp name="85106">
+              <stringProp name="49">1</stringProp>
+            </collectionProp>
+          </collectionProp>
+          <boolProp name="UserParameters.per_iteration">false</boolProp>
+        </UserParameters>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${__P(key)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Calculate loop safe iterations" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">int loopSafeIterations = ${safecount} / ${threadCount};
+
+vars.put(&quot;loopSafeIterations&quot;, loopSafeIterations.toString());</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Safs secrets " enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">${loopSafeIterations}</stringProp>
+        </LoopController>
+        <hashTree>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+            <stringProp name="IfController.condition">(${DateNow}-${BaseDate})&gt;360000</stringProp>
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+          </IfController>
+          <hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Authenticate" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">${__P(key)}</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/authn/${conjurAccount}/host%2Ftest-host-1/authenticate</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:33:44.235664</stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set token" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">import org.apache.commons.codec.binary.Base64;
+
+vars.put(&quot;token&quot;, Base64.encodeBase64String(prev.getResponseDataAsString().getBytes()));</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+              <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Set BaseDate" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">vars.put(&quot;BaseDate&quot;, new Date().getTime().toString());</stringProp>
+              </JSR223PostProcessor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Safe Counter" enabled="true">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end">500</stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">safeNum</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">false</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Accounts" enabled="true">
+            <boolProp name="LoopController.continue_forever">true</boolProp>
+            <stringProp name="LoopController.loops">20</stringProp>
+          </LoopController>
+          <hashTree>
+            <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="Set DateNow" enabled="true">
+              <stringProp name="scriptLanguage">groovy</stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="script">vars.put(&quot;DateNow&quot;, new Date().getTime().toString());</stringProp>
+            </JSR223PreProcessor>
+            <hashTree/>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Batch Retrieve Secrets" enabled="true">
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${readServer}</stringProp>
+              <stringProp name="HTTPSampler.port">443</stringProp>
+              <stringProp name="HTTPSampler.protocol">https</stringProp>
+              <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+              <stringProp name="HTTPSampler.path">/secrets?variable_ids=demo:variable:production%2Fmyapp%2Fdatabase%2Fusername</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+              <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            </HTTPSamplerProxy>
+            <hashTree/>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP HeaderManager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="Authorization" elementType="Header">
+                  <stringProp name="Header.name">Authorization</stringProp>
+                  <stringProp name="Header.value">Token token=&quot;${token}&quot;</stringProp>
+                </elementProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Created from cURL on 2019-12-26T16:35:05.262234</stringProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ResultCollector guiclass="StatGraphVisualizer" testclass="ResultCollector" testname="Aggregate Graph" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename">/Users/hartzi/Desktop/DAP_Performance_Results.jtl</stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename">/Users/hartzi/Desktop/DAP_Performance_Results.jtl</stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>true</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
This PR includes:
- Adds support for generating and populating 150k secrets
- Runs JMeter load test agains instance
- Optionally places generated report into a defined folder so it is not overwritten