### PR TITLE
Bug Fixes

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -15,7 +15,7 @@ function proxy_command {
       echo y | conjur init -u https://conjur-master.mycompany.local -a demo --self-signed --force
     fi
     conjur login -i admin -p MySecretP@ss1
-    hostname -I
+    hostname -i
     eval exec \"$cmd\"
   "
 }

--- a/bin/dap
+++ b/bin/dap
@@ -289,6 +289,10 @@ function _setup_follower {
   _run conjur-follower-1.mycompany.local \
     "evoke unpack seed /opt/cyberark/dap/seeds/follower-seed.tar && evoke configure follower"
 
+  # Copy certs for HAProxy
+  _run conjur-follower-1.mycompany.local \
+    "cp /opt/conjur/etc/ssl/conjur-follower.mycompany.local.key /opt/conjur/etc/ssl/conjur-follower.mycompany.local.pem.key"
+
   _start_l7_load_balancer
   echo "DAP Follower instance available at: 'https://localhost:${CONJUR_FOLLOWER_PORT}'"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   conjur-master.mycompany.local:
-    image: haproxy:2.1-alpine
+    image: haproxy:2.2-alpine
     networks:
       dap_net:
         ipv4_address: 12.16.23.10
@@ -38,6 +38,7 @@ services:
       - ./system/configuration:/opt/cyberark/dap/configuration:Z
       - ./system/logs/master-1:/var/log/conjur:Z
       - ./files:/conjur_files
+
   conjur-master-2.mycompany.local:
     image: registry.tld/conjur-appliance:${VERSION}
     networks:
@@ -123,7 +124,7 @@ services:
       - ./files:/conjur_files
 
   conjur-follower.mycompany.local:
-    image: haproxy:2.1-alpine
+    image: haproxy:2.2-alpine
     networks:
       dap_net:
         ipv4_address: 12.16.23.16

--- a/files/haproxy/follower/haproxy.cfg
+++ b/files/haproxy/follower/haproxy.cfg
@@ -17,7 +17,7 @@ defaults
 
 frontend www
   bind *:80
-  # bind *:443 ssl crt /etc/ssl/certs/conjur-follower.mycompany.local.pem
+  bind *:443 ssl crt /etc/ssl/certs/conjur-follower.mycompany.local.pem
   default_backend www-backend
 
 #


### PR DESCRIPTION
- Update `hostname` command - new Go CLI uses older version, and the `-I` flag isn't available.
- Upgrade HAProxy to v2.2 to fix HTTPS passthrough to Follower.

  Prior to v2.2, HAProxy did not support consuming certificates and private key PEMs in separate files. This has been included, but with a limitation - if the cert is named `name.pem`, the key must be named `name.pem.key`. See haproxy/haproxy#221.

  