### PR TITLE
Give HAProxy permission to read the Follower cert

### DIFF
--- a/bin/dap
+++ b/bin/dap
@@ -291,6 +291,8 @@ function _setup_follower {
   # Copy certs for HAProxy
   _run conjur-follower-1.mycompany.local \
     "cp /opt/conjur/etc/ssl/conjur-follower.mycompany.local.key /opt/conjur/etc/ssl/conjur-follower.mycompany.local.pem.key"
+  _run conjur-follower-1.mycompany.local \
+    "chown 99:99 /opt/conjur/etc/ssl/conjur-follower.mycompany.local.pem.key"
 
   _start_l7_load_balancer
   echo "DAP Follower instance available at: 'https://localhost:${CONJUR_FOLLOWER_PORT}'"


### PR DESCRIPTION
This allows the Follower proxy to run correctly with HTTPS:

This is a follow up to:
https://github.com/conjurdemos/conjur-intro/commit/c04b62ba094c9083e0556d34087eaee3c145205b