### PR TITLE
Kill container when triggering a failover

### DIFF
--- a/bin/dap
+++ b/bin/dap
@@ -517,8 +517,7 @@ function _add_follower_proxy {
 }
 
 function _trigger_master_failover_failover {
-  _run conjur-master-1.mycompany.local \
-    "sv stop conjur"
+  docker compose kill conjur-master-1.mycompany.local
   echo 'Auto-failover takes about a minute to complete.'
 }
 


### PR DESCRIPTION
The desired outcome of this PR is to kill the active Leader when simulating a node failure for auto-failover.

Only stopping the Conjur service has a couple of unintended consequences:

- It allows the services to shut down gently, which is not expected in a system failure.

- It keeps many of the services running which causes unexpected outcomes when simulating a system failure.