### PR TITLE
Pin cfssl build to alpine 3.18

### DIFF
--- a/artifacts/certificate-generator/Dockerfile
+++ b/artifacts/certificate-generator/Dockerfile
@@ -1,4 +1,9 @@
-FROM golang:alpine as builder
+# The pinned golang/alpine verison is to address a build issue here:
+# https://github.com/mattn/go-sqlite3/issues/1164
+#
+# Once the upstream issue is resolved, the base image should be reverted to:
+# golang:alpine
+FROM golang:1.21.5-alpine3.18 as builder
 
 WORKDIR /workdir
 COPY . /workdir


### PR DESCRIPTION
This PR pins the certificator generator base image to alpine 3.18.

It cannot be built with later versions of alpine. More accurately, its dependency on https://github.com/mattn/go-sqlite3
cannot be built. See:
https://github.com/mattn/go-sqlite3/issues/1164