### PR TITLE
remove outdated comment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,6 @@
 version: "3"
 services:
   conjur-master.mycompany.local:
-    # we need to pin version of haproxy to 2.9.0 since the 2.9.1
-    # is consuming enormous amount of CPU affecting the results
-    # of performance tests
-    # https://ca-il-jira.il.cyber-ark.com:8443/browse/CNJR-3477
-    # this should be unpinned to the latest-alpine once the issue
-    # is resolved
     image: haproxy:alpine
     networks:
       dap_net:


### PR DESCRIPTION
remove the comment about pinning the haproxy version, since it is unpinned now