### PR TITLE
Fix host in load test so that it can fetch secrets

### DIFF
--- a/tools/performance-tests/k6/modules/lib.js
+++ b/tools/performance-tests/k6/modules/lib.js
@@ -168,7 +168,7 @@ export function createHostsPolicy(identifier) {
             role: !layer hosts
             members: *lob-1-safe-1-hosts
 - !grant
-  role: !group AutomationVault/lob-1-${identifier}/safe-1-${identifier}/delegation/viewers
+  role: !group AutomationVault/lob-1-${identifier}/safe-1-${identifier}/delegation/consumers
   members: !layer AutomationVault-hosts/lob-1-${identifier}/safe-1-${identifier}/hosts`;
 }
 


### PR DESCRIPTION
Simple fix so that future scenarios can properly fetch secret values using a host created by this function. Viewers role only has "read" privileges to resources meaning it can only view metadata.