### PR TITLE
Limit the number of CPUs assumed by each Follower container

### DIFF
--- a/bin/dap
+++ b/bin/dap
@@ -355,6 +355,9 @@ function _setup_follower {
   docker compose rm --stop --force "$follower_service_name"
   docker compose up --no-deps --detach "$follower_service_name"
 
+  # Pin the number of nginx worker processes to avoid issues running on a large test VM
+  _run "$follower_service_name" "sed -i 's/worker_processes auto;/worker_processes 4;/g' /etc/nginx/nginx.conf"
+
   # Unpack and Configure
   echo "Unpacking and configuring Follower: '$follower_service_name'..."
   _run "$follower_service_name" \

--- a/bin/dap
+++ b/bin/dap
@@ -358,6 +358,9 @@ function _setup_follower {
   # Pin the number of nginx worker processes to avoid issues running on a large test VM
   _run "$follower_service_name" "sed -i 's/worker_processes auto;/worker_processes 4;/g' /etc/nginx/nginx.conf"
 
+  # Configure timescale db not to use all of the CPUs
+  _run "$follower_service_name" "sed -i 's/timescaledb-tune --yes/timescaledb-tune --yes --cpus=4/g' /opt/conjur/evoke/chef/cookbooks/conjur/recipes/postgres.rb"
+
   # Unpack and Configure
   echo "Unpacking and configuring Follower: '$follower_service_name'..."
   _run "$follower_service_name" \


### PR DESCRIPTION
The desired outcome of this PR is to prevent each Follower in the test from attempting to use all of the CPUs available on the host machine.

The host VM for this test has a high number of CPUs available (64?) in order to run 50+ containers simultaneously. However, each Follower attempts to tune nginx and the audit database for the number of CPUs it sees, leading to more worker processes per Follower than is realistic or expected.

This PR pins the number of CPUs that the Follower tunes to to 4 to prevent this worker process overrun from occurring.