### PR TITLE
Bump golang version to 1.24 in k6 docker image

### DIFF
--- a/tools/performance-tests/k6/Dockerfile
+++ b/tools/performance-tests/k6/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 WORKDIR /src
 
 # On CyberArk dev laptops, internet connections route through


### PR DESCRIPTION
Bump the version of go-alpine image used as the builder for k6 image