### PR TITLE
CNJR-9101: Deprecate conjur-kubernetes-authenticator image

### DIFF
--- a/demos/openshift-install/templates/conjur-java-api-example.yaml
+++ b/demos/openshift-install/templates/conjur-java-api-example.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: default
       containers:
-      - image: cyberark/conjur-kubernetes-authenticator:latest
+      - image: cyberark/conjur-authn-k8s-client:latest
         imagePullPolicy: IfNotPresent
         name: authenticator
         env:


### PR DESCRIPTION
The conjur-kubernetes-authenticator Docker image has been deprecated in favor of conjur-authn-k8s-client and will soon stop being updated. Use the new name instead.

Related to https://github.com/cyberark/conjur-authn-k8s-client/issues/148