### PR TITLE
Build k6 image with cache and pull option enabled

### DIFF
--- a/bin/load-test
+++ b/bin/load-test
@@ -93,7 +93,7 @@ test_k6() {
 
   # build K6 image
   "$(repo_root)/bin/retrieve_cyberark_ca_cert"
-  docker compose build k6 --no-cache
+  docker compose build --pull k6
 
   if [ "$WARMUP" == "true" ]; then
     # Warmup


### PR DESCRIPTION
Remove --no-cache flag to not increase the cache per every load test execution
Add --pull flag to update the image in case of upstream changes to the k6 repo