### PR TITLE
CNJR-7838: Use APPLIANCE_READ_URL in dynamic secrets tests

### DIFF
--- a/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-dynamic-secrets.js
+++ b/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-dynamic-secrets.js
@@ -63,7 +63,7 @@ export function authn() {
 }
 
 export default function () {
-  env.applianceUrl = env.applianceMasterUrl
+  env.applianceUrl = env.applianceReadUrl
   authn()
   const {uniqueIdentifierPrefix} = env;
   let identifier = '/' + (uniqueIdentifierPrefix || '') + `${__VU}-${__ITER}`

--- a/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-static-secrets.js
+++ b/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-static-secrets.js
@@ -63,7 +63,7 @@ export function authn() {
 }
 
 export default function () {
-  env.applianceUrl = env.applianceMasterUrl
+  env.applianceUrl = env.applianceReadUrl
   authn()
   const {uniqueIdentifierPrefix} = env;
   let identifier = (uniqueIdentifierPrefix || '') + `${__VU}-${__ITER}`


### PR DESCRIPTION
Expands upon #179 to make the dynamic secrets READ tests more configurable against either a Leader or a Follower