### PR TITLE
CNJR-7838: Remove dynamic secerts from read individually load test

### DIFF
--- a/tools/performance-tests/k6/scenarios/read-individually.js
+++ b/tools/performance-tests/k6/scenarios/read-individually.js
@@ -23,10 +23,8 @@ const requiredEnvVars = [
 // These are custom k6 metrics that will be reported in the k6 summary.
 const authenticateTrend = new Trend('http_req_duration_post_authn', true);
 const authenticateFailRate = new Rate('http_req_failed_post_authn');
-const readStaticSecretsIndividuallyTrend = new Trend('http_req_duration_get_static_secrets_individually', true);
-const readStaticSecretsIndividuallyFailRate = new Rate('http_req_failed_get_static_secrets_individually');
-const readDynamicSecretsIndividuallyTrend = new Trend('http_req_duration_get_dynamic_secrets_individually', true);
-const readDynamicSecretsIndividuallyFailRate = new Rate('http_req_failed_get_dynamic_secrets_individually');
+const readSecretsIndividuallyTrend = new Trend('http_req_duration_get_secrets_individually', true);
+const readSecretsIndividuallyFailRate = new Rate('http_req_failed_get_secrets_individually');
 
 lib.checkRequiredEnvironmentVariables(requiredEnvVars);
 const gracefulStop = lib.getEnvVar("K6_CUSTOM_GRACEFUL_STOP");
@@ -98,26 +96,12 @@ export default function () {
   const variableNumber = Math.ceil(Math.random() * 5) || 1;
   const identity = `AutomationVault/${apiKey.lob_name}/${apiKey.safe_name}/account-${accountNumber}${uuid_suffix}/variable-${variableNumber}${uuid_suffix}`;
 
-  // Read static secret
-  const resStatic = conjurApi.readSecret(http, env, identity);
+  const res = conjurApi.readSecret(http, env, identity);
 
-  readStaticSecretsIndividuallyTrend.add(resStatic.timings.duration);
-  readStaticSecretsIndividuallyFailRate.add(resStatic.status !== 200);
+  readSecretsIndividuallyTrend.add(res.timings.duration);
+  readSecretsIndividuallyFailRate.add(res.status !== 200);
 
-  check(resStatic, {
-    "status is 200": (r) => r.status === 200,
-    "status is not 404": (r) => r.status !== 404,
-    "status is not 401": (r) => r.status !== 401,
-    "status is not 500": (r) => r.status !== 500
-  });
-
-  // Read dynamic secret
-  const resDynamic = conjurApi.readSecret(http, env, 'data/dynamic/' + identity);
-
-  readDynamicSecretsIndividuallyTrend.add(resDynamic.timings.duration);
-  readDynamicSecretsIndividuallyFailRate.add(resDynamic.status !== 200);
-
-  check(resDynamic, {
+  check(res, {
     "status is 200": (r) => r.status === 200,
     "status is not 404": (r) => r.status !== 404,
     "status is not 401": (r) => r.status !== 401,
@@ -130,11 +114,8 @@ export function handleSummary(data) {
     iterations: {
       values: {rate: httpReqs}
     },
-    http_req_duration_get_static_secrets_individually: {
-      values: {avg: avgResponseTimeStatic, max: maxResponseTimeStatic, min: minResponseTimeStatic}
-    },
-    http_req_duration_get_dynamic_secrets_individually: {
-      values: {avg: avgResponseTimeDynamic, max: maxResponseTimeDynamic, min: minResponseTimeDynamic}
+    http_req_duration_get_secrets_individually: {
+      values: {avg: avgResponseTime, max: maxResponseTime, min: minResponseTime}
     },
     http_req_failed: {
       values: {rate: failRate}
@@ -144,11 +125,11 @@ export function handleSummary(data) {
     }
   } = data['metrics'];
 
-  const testName = "Retrieve a single static and dynamic secret";
+  const testName = "Retrieve a single secret";
   const nodeType = lib.checkNodeType(env.applianceReadUrl);
 
   const csv = papaparse.unparse(
-    lib.generateMetricsArray(nodeType, testName, vusMax, httpReqs, avgResponseTimeStatic, maxResponseTimeStatic, minResponseTimeStatic, avgResponseTimeDynamic, maxResponseTimeDynamic, minResponseTimeDynamic, failRate)
+    lib.generateMetricsArray(nodeType, testName, vusMax, httpReqs, avgResponseTime, maxResponseTime, minResponseTime, failRate)
   );
 
   return {

--- a/tools/performance-tests/k6/scenarios/static-dynamic-secrets/create-dynamic-secrets-policy.js
+++ b/tools/performance-tests/k6/scenarios/static-dynamic-secrets/create-dynamic-secrets-policy.js
@@ -40,9 +40,6 @@ export const options = {
       iterations: vus,
       gracefulStop
     },
-  }, thresholds: {
-    iterations: ['rate > 1'],
-    checks: ['rate == 1.0']
   }
 };
 
@@ -110,19 +107,26 @@ export default function () {
 
 export function handleSummary(data) {
   const {
+    iterations: {
+      values: {rate: httpReqs}
+    },
     http_req_duration_create_dynamic_secrets_policy: {
-      values: {avg: avgResponseTimeCreateDynamicSecretsPolicy, max: maxResponseTimeCreateDynamicSecretsPolicy, min: minResponseTimeCreateDynamicSecretsPolicy}
+      values: {avg: avgResponseTime, max: maxResponseTime, min: minResponseTime}
     },
     http_req_failed: {
       values: {rate: failRate}
+    },
+    vus_max: {
+      values: {max: vusMax}
     }
   } = data['metrics'];
 
+
   const testName = "Create Dynamic Secrets Policy";
-  const nodeType = lib.checkNodeType(env.applianceReadUrl);
+  const nodeType = lib.checkNodeType(env.applianceMasterUrl);
 
   const csv = papaparse.unparse(
-    lib.generateMetricsArray(nodeType, testName, failRate, avgResponseTimeCreateDynamicSecretsPolicy, maxResponseTimeCreateDynamicSecretsPolicy, minResponseTimeCreateDynamicSecretsPolicy)
+    lib.generateMetricsArray(nodeType, testName, vusMax, httpReqs, avgResponseTime, maxResponseTime, minResponseTime, failRate)
   );
 
   return {

--- a/tools/performance-tests/k6/scenarios/static-dynamic-secrets/create-static-secrets-policy.js
+++ b/tools/performance-tests/k6/scenarios/static-dynamic-secrets/create-static-secrets-policy.js
@@ -38,9 +38,6 @@ export const options = {
       iterations: vus,
       gracefulStop
     },
-  }, thresholds: {
-    iterations: ['rate > 1'],
-    checks: ['rate == 1.0']
   }
 };
 
@@ -90,19 +87,26 @@ export default function () {
 
 export function handleSummary(data) {
   const {
+    iterations: {
+      values: {rate: httpReqs}
+    },
     http_req_duration_create_static_secrets_policy: {
-      values: {avg: avgResponseTimeCreateStaticSecretsPolicy, max: maxResponseTimeCreateStaticSecretsPolicy, min: minResponseTimeCreateStaticSecretsPolicy}
+      values: {avg: avgResponseTime, max: maxResponseTime, min: minResponseTime}
     },
     http_req_failed: {
       values: {rate: failRate}
+    },
+    vus_max: {
+      values: {max: vusMax}
     }
   } = data['metrics'];
 
+
   const testName = "Create Static Secrets Policy";
-  const nodeType = lib.checkNodeType(env.applianceReadUrl);
+  const nodeType = lib.checkNodeType(env.applianceMasterUrl);
 
   const csv = papaparse.unparse(
-    lib.generateMetricsArray(nodeType, testName, failRate, avgResponseTimeCreateStaticSecretsPolicy, maxResponseTimeCreateStaticSecretsPolicy, minResponseTimeCreateStaticSecretsPolicy)
+    lib.generateMetricsArray(nodeType, testName, vusMax, httpReqs, avgResponseTime, maxResponseTime, minResponseTime, failRate)
   );
 
   return {

--- a/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-dynamic-secrets.js
+++ b/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-dynamic-secrets.js
@@ -41,9 +41,6 @@ export const options = {
       iterations: iterations,
       gracefulStop
     },
-  }, thresholds: {
-    iterations: ['rate > 1'],
-    checks: ['rate == 1.0']
   }
 };
 
@@ -85,11 +82,11 @@ export default function () {
 
 export function handleSummary(data) {
   const {
-    iterations_read_dynamic_secrets_count: {
-      values: {rate: httpReqsReadDynamicSecret}
+    iterations: {
+      values: {rate: httpReqs}
     },
     http_req_duration_read_dynamic_secrets: {
-      values: {avg: avgResponseTimeReadDynamic, max: maxResponseTimeReadDynamic, min: minResponseTimeReadDynamic}
+      values: {avg: avgResponseTime, max: maxResponseTime, min: minResponseTime}
     },
     http_req_failed: {
       values: {rate: failRate}
@@ -99,16 +96,16 @@ export function handleSummary(data) {
     }
   } = data['metrics'];
 
-  const testName = "Create Dynamicc Secrets Policy";
+  const testName = "Read Dynamic Secrets";
   const nodeType = lib.checkNodeType(env.applianceReadUrl);
 
   const csv = papaparse.unparse(
-    lib.generateMetricsArray(nodeType, testName, vusMax, failRate, httpReqsReadDynamicSecret, avgResponseTimeReadDynamic, maxResponseTimeReadDynamic, minResponseTimeReadDynamic)
+    lib.generateMetricsArray(nodeType, testName, vusMax, httpReqs, avgResponseTime, maxResponseTime, minResponseTime, failRate)
   );
 
   return {
     "./tools/performance-tests/k6/reports/metrics.csv": csv,
-    "./tools/performance-tests/k6/reports/create-dynamic-secrets-policy-summary.html": htmlReport(data, {title: "Create Dynamicc Secrets Policy" + new Date().toISOString().slice(0, 16).replace('T', ' ')}),
+    "./tools/performance-tests/k6/reports/read-dynamic-secrets-summary.html": htmlReport(data, {title: "Read Dynamic Secrets" + new Date().toISOString().slice(0, 16).replace('T', ' ')}),
     stdout: textSummary(data, {indent: " ", enableColors: true}),
   };
 }

--- a/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-static-secrets.js
+++ b/tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-static-secrets.js
@@ -41,9 +41,6 @@ export const options = {
       iterations: iterations,
       gracefulStop
     },
-  }, thresholds: {
-    iterations: ['rate > 1'],
-    checks: ['rate == 1.0']
   }
 };
 
@@ -85,11 +82,11 @@ export default function () {
 
 export function handleSummary(data) {
   const {
-    iterations_read_static_secrets_count: {
-      values: {rate: httpReqsReadStaticSecret}
+    iterations: {
+      values: {rate: httpReqs}
     },
     http_req_duration_read_static_secrets: {
-      values: {avg: avgResponseTimeReadStatic, max: maxResponseTimeReadStatic, min: minResponseTimeReadStatic}
+      values: {avg: avgResponseTime, max: maxResponseTime, min: minResponseTime}
     },
     http_req_failed: {
       values: {rate: failRate}
@@ -99,16 +96,16 @@ export function handleSummary(data) {
     }
   } = data['metrics'];
 
-  const testName = "Create Static Secrets Policy";
+  const testName = "Read Static Secrets";
   const nodeType = lib.checkNodeType(env.applianceReadUrl);
 
   const csv = papaparse.unparse(
-    lib.generateMetricsArray(nodeType, testName, vusMax, failRate, httpReqsReadStaticSecret, avgResponseTimeReadStatic, maxResponseTimeReadStatic, minResponseTimeReadStatic)
+    lib.generateMetricsArray(nodeType, testName, vusMax, httpReqs, avgResponseTime, maxResponseTime, minResponseTime, failRate)
   );
 
   return {
     "./tools/performance-tests/k6/reports/metrics.csv": csv,
-    "./tools/performance-tests/k6/reports/create-static-secrets-policy-summary.html": htmlReport(data, {title: "Create Static Secrets Policy" + new Date().toISOString().slice(0, 16).replace('T', ' ')}),
+    "./tools/performance-tests/k6/reports/read-static-secrets-summary.html": htmlReport(data, {title: "Read Static Secrets" + new Date().toISOString().slice(0, 16).replace('T', ' ')}),
     stdout: textSummary(data, {indent: " ", enableColors: true}),
   };
 }

--- a/tools/performance-tests/k6/scenarios/static-dynamic-secrets/write-static-secrets.js
+++ b/tools/performance-tests/k6/scenarios/static-dynamic-secrets/write-static-secrets.js
@@ -41,10 +41,9 @@ export const options = {
       iterations: iterations,
       gracefulStop
     },
-  }, thresholds: {
-    iterations: ['rate > 1'],
-    checks: ['rate == 1.0']
   }
+  // We do not need a threshold here, since we're just populating secrets for
+  // the read scenarios.
 };
 
 export function authn() {
@@ -88,11 +87,11 @@ export default function () {
 
 export function handleSummary(data) {
   const {
-    iterations_write_static_secrets_count: {
-      values: {rate: httpReqsWriteStaticSecret}
+    iterations: {
+      values: {rate: httpReqs}
     },
     http_req_duration_write_static_secrets: {
-      values: {avg: avgResponseTimeWriteStatic, max: maxResponseTimeWriteStatic, min: minResponseTimeWriteStatic}
+      values: {avg: avgResponseTime, max: maxResponseTime, min: minResponseTime}
     },
     http_req_failed: {
       values: {rate: failRate}
@@ -102,16 +101,17 @@ export function handleSummary(data) {
     }
   } = data['metrics'];
 
-  const testName = "Create Static Secrets Policy";
-  const nodeType = lib.checkNodeType(env.applianceReadUrl);
+
+  const testName = "Write Static Secrets";
+  const nodeType = lib.checkNodeType(env.applianceMasterUrl);
 
   const csv = papaparse.unparse(
-    lib.generateMetricsArray(nodeType, testName, vusMax, failRate, httpReqsWriteStaticSecret, avgResponseTimeWriteStatic, maxResponseTimeWriteStatic, minResponseTimeWriteStatic)
+    lib.generateMetricsArray(nodeType, testName, vusMax, httpReqs, avgResponseTime, maxResponseTime, minResponseTime, failRate)
   );
 
   return {
     "./tools/performance-tests/k6/reports/metrics.csv": csv,
-    "./tools/performance-tests/k6/reports/create-static-secrets-policy-summary.html": htmlReport(data, {title: "Create Static Secrets Policy" + new Date().toISOString().slice(0, 16).replace('T', ' ')}),
+    "./tools/performance-tests/k6/reports/write-static-secrets-summary.html": htmlReport(data, {title: "Write Static Secrets" + new Date().toISOString().slice(0, 16).replace('T', ' ')}),
     stdout: textSummary(data, {indent: " ", enableColors: true}),
   };
 }


### PR DESCRIPTION
    Remove the thresholds for dynamic secrets
    
    - Remove dynamic secrets from read individually load test (not needed in this test anymore, since these have been moved to their own file)
    - Fix typos in summary output (resulting csv file was incorrectly generated due to incorrect parameter order)
    - Remove thresholds from dynamic secrets related tests, as we have yet to determine what those will be. Will be done in a separate ticket.    

   Related #179  #182 