### PR TITLE
CNJR-7796: Add Conjur CSI provider config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ $ bin/dap --provision-k8s-follower
 More information about way of how the Follower is deployed into Kubernetes
 cluster can be found in [README.md](artifacts/k8s-follower-orchestrator/README.md)
 
+### Integration Examples
+
+Deploy the Conjur Provider for Secrets Store CSI Driver in Kubernetes (kind):
+  
+```sh
+$ bin/dap --provision-csi-provider
+```
+
 ### Working with Podman
 
 The project is enabled to work with Podman instead of Docker.
@@ -93,6 +101,7 @@ To connect to the UI in the browser, use ports 10443(through HA proxy) or 10444(
 |--provision-k8s-follower|action|• Removes follower if present<br>• Configures follower inside kubernetes cluster ran by kind|Requires configured master|
 |--provision-master|action|• Starts a DAP container and Layer 4 load balancer<br>• Configures with account `demo` and password `MySecretP@ss1`||
 |--provision-standbys|action|• Removes standbys if present<br>• Starts two DAP containers<br>• Generates standby seed files<br>• Configures standbys<br>• Enable Synchronous Standby|Requires configured master|
+|--provision-csi-provider|action|• Configures Conjur CSI Provider inside kubernetes cluster ran by kind|Requires configured master|
 |--restore-from-backup|action|• Removes auto-failover (if enabled)<br>• Stops and renames master<br>• Starts new DAP container<br>• Restores master from backup|Requires a previously created backup|
 |--stop|action|Stops and removes all containers||
 |--trigger-failover|action|• Stops current master|Requires an auto-failover cluster|
@@ -166,6 +175,7 @@ Usage: bin/dap single [options]
     --provision-k8s-follower          Configures follower inside kubernetes cluster ran by kind (Requires configured master)
     --provision-master                Configures a DAP Master with account `demo` and password `MySecretP@ss1` behind a Layer 4 load balancer
     --provision-standbys              Deploys and configures two standbys (Requires configured master)
+    -provision-csi-provider           Configures Conjur CSI provider inside kubernetes cluster ran by kind (Requires configured master)
     --restore-from-backup             Restores a master from backup|Requires a previously created backup
     --provision-keycloak              Configures Keycloak OIDC authenticator (Requires configured master)
     --stop                            Stops all containers and cleans up cached files

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Usage: bin/dap single [options]
     --provision-k8s-follower          Configures follower inside kubernetes cluster ran by kind (Requires configured master)
     --provision-master                Configures a DAP Master with account `demo` and password `MySecretP@ss1` behind a Layer 4 load balancer
     --provision-standbys              Deploys and configures two standbys (Requires configured master)
-    -provision-csi-provider           Configures Conjur CSI provider inside kubernetes cluster ran by kind (Requires configured master)
+    --provision-csi-provider          Configures Conjur CSI provider inside kubernetes cluster ran by kind (Requires configured master)
     --restore-from-backup             Restores a master from backup|Requires a previously created backup
     --provision-keycloak              Configures Keycloak OIDC authenticator (Requires configured master)
     --stop                            Stops all containers and cleans up cached files

--- a/artifacts/k8s-csi-provider/Dockerfile
+++ b/artifacts/k8s-csi-provider/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:latest
 
+ARG GO_VERSION=1.24.4
+ARG KIND_VERSION=0.29.0
+ARG KUBECTL_VERSION=1.33.2
+
 # Install dependencies
 RUN apt-get update -y && \
     apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget jq gettext-base
@@ -8,16 +12,17 @@ RUN apt-get update -y && \
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
     chmod +x /usr/bin/yq
 
-# Install Go 1.22.1
-RUN wget https://go.dev/dl/go1.22.1.linux-amd64.tar.gz && \
-    tar -xf go1.22.1.linux-amd64.tar.gz && \
-    mv go /usr/local/
+# Install Go
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -xf go${GO_VERSION}.linux-amd64.tar.gz && \
+    mv go /usr/local/ && \
+    rm go${GO_VERSION}.linux-amd64.tar.gz
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/root/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 # Install KinD
-RUN go install sigs.k8s.io/kind@v0.20.0
+RUN go install sigs.k8s.io/kind@v${KIND_VERSION}
 
 # Install Docker client
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
@@ -27,16 +32,14 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
     rm -rf /var/lib/apt/lists/*
 
 # Install kubectl CLI
-ARG KUBECTL_VERSION
-RUN curl -LO https://dl.k8s.io/release/v"${KUBECTL_VERSION:-1.21.3}"/bin/linux/amd64/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     mv kubectl /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 # Install Helm CLI
-ARG HELM_CLI_VERSION
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
     chmod 700 get_helm.sh && \
-    ./get_helm.sh --no-sudo --version ${HELM_CLI_VERSION:-v3.5.2}
+    ./get_helm.sh --no-sudo
 
 WORKDIR /
 ADD entrypoint.sh ./

--- a/artifacts/k8s-csi-provider/Dockerfile
+++ b/artifacts/k8s-csi-provider/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:latest
+
+# Install dependencies
+RUN apt-get update -y && \
+    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget jq gettext-base
+
+# Install yq
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+    chmod +x /usr/bin/yq
+
+# Install Go 1.22.1
+RUN wget https://go.dev/dl/go1.22.1.linux-amd64.tar.gz && \
+    tar -xf go1.22.1.linux-amd64.tar.gz && \
+    mv go /usr/local/
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/root/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+# Install KinD
+RUN go install sigs.k8s.io/kind@v0.20.0
+
+# Install Docker client
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install kubectl CLI
+ARG KUBECTL_VERSION
+RUN curl -LO https://dl.k8s.io/release/v"${KUBECTL_VERSION:-1.21.3}"/bin/linux/amd64/kubectl && \
+    mv kubectl /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+# Install Helm CLI
+ARG HELM_CLI_VERSION
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
+    chmod 700 get_helm.sh && \
+    ./get_helm.sh --no-sudo --version ${HELM_CLI_VERSION:-v3.5.2}
+
+WORKDIR /
+ADD entrypoint.sh ./
+RUN chmod +x ./entrypoint.sh
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/artifacts/k8s-csi-provider/entrypoint.sh
+++ b/artifacts/k8s-csi-provider/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+export KIND_EXPERIMENTAL_DOCKER_NETWORK=dap_net
+export CLUSTER_NAME=conjur-intro-csi-provider
+
+cleanup() {
+  echo "Cleaning up..."
+  kind delete cluster --name $CLUSTER_NAME
+}
+
+trap cleanup SIGINT SIGTERM
+
+echo "Deleting cluster if exists..."
+kind delete cluster --name $CLUSTER_NAME || true
+echo "Creating cluster..."
+
+kind create cluster --name $CLUSTER_NAME
+
+kind_cid="$(docker inspect --format="{{.Id}}" $CLUSTER_NAME-control-plane)"
+kind_ip="$(dirname "$(docker network inspect $KIND_EXPERIMENTAL_DOCKER_NETWORK | yq ".[0][\"Containers\"][\"$kind_cid\"][\"IPv4Address\"]")")"
+kind_port="$(dirname "$(docker port $CLUSTER_NAME-control-plane)")"
+kubectl config set clusters.kind-$CLUSTER_NAME.server "https://$kind_ip:$kind_port"
+kubectl config use-context kind-$CLUSTER_NAME
+
+nohup sleep infinity &
+wait $!
+
+set +e

--- a/artifacts/k8s-csi-provider/helm/test-app/Chart.yaml
+++ b/artifacts/k8s-csi-provider/helm/test-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: A Helm chart for deploying CyberArk Conjur's CSI Driver Provider test app
+name: conjur-k8s-csi-provider-test-app
+version: 0.2.0
+home: https://github.com/cyberark/conjur-k8s-csi-provider
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/artifacts/k8s-csi-provider/helm/test-app/templates/app.yaml
+++ b/artifacts/k8s-csi-provider/helm/test-app/templates/app.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    conjur.org/secrets: |
+{{ .Values.conjur.secrets | indent 6 }}
+spec:
+  serviceAccountName: {{ .Values.serviceAccount.name }}
+  containers:
+    - name: app
+      image: alpine:latest
+      imagePullPolicy: Always
+      command: [ "/bin/sh", "-c", "--" ]
+      args: [ "while true; do sleep 30; done;" ]
+      volumeMounts:
+        - name: conjur-csi-provider-volume
+          mountPath: /mnt/secrets-store
+          readOnly: true
+      securityContext:
+        allowPrivilegeEscalation: false
+  volumes:
+    - name: conjur-csi-provider-volume
+      csi:
+        driver: 'secrets-store.csi.k8s.io'
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: {{ .Values.secretProviderClass.name }}

--- a/artifacts/k8s-csi-provider/helm/test-app/templates/secret-provider-class.yaml
+++ b/artifacts/k8s-csi-provider/helm/test-app/templates/secret-provider-class.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.secretProviderClass.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  provider: conjur
+  parameters:
+    conjur.org/configurationVersion: {{ .Values.conjur.configurationVersion }}
+    account: {{ .Values.conjur.account }}
+    applianceUrl: {{ .Values.conjur.applianceUrl }}
+    authnId: {{ .Values.conjur.authnId }}
+    secrets: |
+{{ .Values.conjur.secrets | indent 6 }}
+    sslCertificate: |
+{{ .Values.conjur.sslCertificate | indent 6 }}

--- a/artifacts/k8s-csi-provider/helm/test-app/values.yaml
+++ b/artifacts/k8s-csi-provider/helm/test-app/values.yaml
@@ -1,0 +1,15 @@
+# Values for conjur-k8s-csi-provider-test-app. All missing values must be supplied by the user.
+
+secretProviderClass:
+  name: database-credentials
+
+conjur:
+  configurationVersion:
+  account:
+  applianceUrl:
+  authnId:
+  secrets:
+  sslCertificate:
+
+serviceAccount:
+  name:

--- a/artifacts/k8s-csi-provider/jwt-authenticator-webservice-policy.yaml
+++ b/artifacts/k8s-csi-provider/jwt-authenticator-webservice-policy.yaml
@@ -1,0 +1,42 @@
+- !policy
+  id: conjur/authn-jwt/dev-cluster
+  body:
+    - !webservice
+
+      # Uncomment one of following variables depending on the public availability
+      # of the Service Account Issuer Discovery service in Kubernetes
+      # If the service is publicly available, uncomment 'jwks-uri'.
+      # If the service is not available, uncomment 'public-keys'
+    # - !variable jwks-uri
+    - !variable public-keys
+
+    - !variable issuer
+    - !variable token-app-property
+    - !variable identity-path
+    - !variable audience
+
+    # Group of applications that can authenticate using this JWT Authenticator
+    - !group apps
+
+    - !permit
+      role: !group apps
+      privilege: [ read, authenticate ]
+      resource: !webservice
+
+    - !webservice status
+
+    - !grant
+      role: !group apps
+      member: !user /admin
+
+    # Group of users who can check the status of the JWT Authenticator
+    - !group operators
+
+    - !permit
+      role: !group operators
+      privilege: [ read ]
+      resource: !webservice status
+
+    - !grant
+      role: !group operators
+      member: !user /admin

--- a/artifacts/k8s-csi-provider/test-app-policy.yaml
+++ b/artifacts/k8s-csi-provider/test-app-policy.yaml
@@ -1,0 +1,25 @@
+- !host
+  id: apps/system:serviceaccount:test-app:test-app-sa
+
+  annotations:
+    authn-jwt/dev-cluster/kubernetes.io/namespace: test-app
+    authn-jwt/dev-cluster/kubernetes.io/serviceaccount/name: test-app-sa
+
+- !grant
+  roles:
+    - !group conjur/authn-jwt/dev-cluster/apps
+  members:
+    - !host apps/system:serviceaccount:test-app:test-app-sa
+
+- !variable db-credentials/url
+- !variable db-credentials/username
+- !variable db-credentials/password
+
+- !permit 
+  roles:
+    - !group conjur/authn-jwt/dev-cluster/apps
+  privileges: [ read, execute ]
+  resources:
+    - !variable db-credentials/url
+    - !variable db-credentials/username
+    - !variable db-credentials/password

--- a/bin/dap
+++ b/bin/dap
@@ -49,7 +49,7 @@ Usage: bin/dap [options]:
     --provision-k8s-follower                                  Configures follower inside kubernetes cluster ran by kind
                                                                 (Requires configured master).
 
-    -provision-csi-provider                                   Configures Conjur CSI provider inside kubernetes cluster ran by kind
+    --provision-csi-provider                                  Configures Conjur CSI provider inside kubernetes cluster ran by kind
                                                                 (Requires configured master).
 
     --provision-master                                        Configures a DAP Master with account `demo` and

--- a/bin/dap
+++ b/bin/dap
@@ -49,6 +49,9 @@ Usage: bin/dap [options]:
     --provision-k8s-follower                                  Configures follower inside kubernetes cluster ran by kind
                                                                 (Requires configured master).
 
+    -provision-csi-provider                                   Configures Conjur CSI provider inside kubernetes cluster ran by kind
+                                                                (Requires configured master).
+
     --provision-master                                        Configures a DAP Master with account `demo` and
                                                                 password `MySecretP@ss1` behind a Layer 4 load
                                                                 balancer.
@@ -419,6 +422,99 @@ function pull_k8s_follower_images {
     docker tag "${img}" "${img_without_registry}"
     _run_in_kind "kind load docker-image ${img_without_registry} --name conjur-intro-k8s-follower"
   done
+}
+
+function _setup_csi_provider {
+  touch kubeconfig
+  docker compose rm --stop --force csi-provider-orchestrator
+  docker compose build csi-provider-orchestrator
+  docker compose up --no-deps --detach csi-provider-orchestrator
+
+  # Loop until we get a response from the Kubernetes API
+  SECONDS=0
+  TIMEOUT=300
+  while true; do
+    if docker compose exec -T csi-provider-orchestrator bash -c "kubectl get nodes" &> /dev/null; then
+      echo "The conjur-intro-csi-provider cluster is created."
+      break
+    else
+      echo "Waiting for the conjur-intro-csi-provider cluster to be created..."
+      sleep 1
+    fi
+    if [ $SECONDS -ge $TIMEOUT ]; then
+        echo "Timeout after waiting for 5 minutes. The conjur-intro-csi-provider cluster is not created."
+        echo "Printing logs from csi-provider-orchestrator container:"
+        docker compose logs csi-provider-orchestrator
+        exit 1
+      fi
+  done
+
+  # Define and enable the JWT Authenticator in Conjur
+  bin/cli conjur policy load -b root -f artifacts/k8s-csi-provider/jwt-authenticator-webservice-policy.yaml
+  jwks=$(docker compose exec -T csi-provider-orchestrator bash -c "kubectl get --raw \$(kubectl get --raw /.well-known/openid-configuration | jq -r '.jwks_uri')")
+  policy_value="{\"type\":\"jwks\",\"value\":$jwks}"
+  curl -k -X POST \
+    -H "$(bin/cli conjur authenticate -H | tail -n1)" \
+    --data "$policy_value" \
+    "https://localhost/secrets/demo/variable/conjur%2Fauthn-jwt%2Fdev-cluster%2Fpublic-keys"
+  bin/cli conjur variable set -i conjur/authn-jwt/dev-cluster/issuer -v https://kubernetes.default.svc.cluster.local
+  bin/cli conjur variable set -i conjur/authn-jwt/dev-cluster/token-app-property -v "sub"
+  bin/cli conjur variable set -i conjur/authn-jwt/dev-cluster/identity-path -v apps
+  bin/cli conjur variable set -i conjur/authn-jwt/dev-cluster/audience -v "conjur"
+  _append_conjur_authenticator "authn-jwt/dev-cluster"
+
+
+  # Prep helm repos
+  docker compose exec -T csi-provider-orchestrator bash -c "helm repo add cyberark --insecure-skip-tls-verify https://cyberark.github.io/helm-charts"
+  docker compose exec -T csi-provider-orchestrator bash -c "helm repo add secrets-store-csi-driver --insecure-skip-tls-verify https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"
+  docker compose exec -T csi-provider-orchestrator bash -c "helm repo update"
+
+  # Install the Secrets Store CSI Driver 
+  docker compose exec -T csi-provider-orchestrator bash -c "helm install csi-secrets-store \
+      secrets-store-csi-driver/secrets-store-csi-driver \
+      --namespace csi \
+      --create-namespace \
+      --insecure-skip-tls-verify \
+      --set \"linux.providersDir=/var/run/secrets-store-csi-providers\" \
+      --set syncSecret.enabled=\"true\" \
+      --set \"tokenRequests[0].audience=conjur\"
+    "
+
+  # Load the test-app policy into Conjur and set some example variables
+  bin/cli conjur policy load -f artifacts/k8s-csi-provider/test-app-policy.yaml -b root
+  bin/cli conjur variable set -i db-credentials/url -v "https://some-db.example.com:5432"
+  bin/cli conjur variable set -i db-credentials/username -v "db-user"
+  bin/cli conjur variable set -i db-credentials/password -v "db-password"
+
+  # Install the Conjur Provider
+  docker compose exec -T csi-provider-orchestrator bash -c "helm install --debug conjur-provider \
+      cyberark/conjur-k8s-csi-provider \
+      --wait \
+      --namespace csi \
+      --insecure-skip-tls-verify \
+      --set daemonSet.image.repo=\"cyberark/conjur-k8s-csi-provider\" \
+      --set daemonSet.image.tag=\"latest\"
+    "
+
+  # Deploy a test app
+  export TEST_APP_NAMESPACE="test-app"
+  export TEST_APP_SA="test-app-sa"
+  docker compose exec -T csi-provider-orchestrator bash -c "kubectl create namespace $TEST_APP_NAMESPACE"
+  docker compose exec -T csi-provider-orchestrator bash -c "kubectl create serviceaccount $TEST_APP_SA -n $TEST_APP_NAMESPACE"
+
+  docker compose exec -T csi-provider-orchestrator bash -c "helm install test-app /artifacts/k8s-csi-provider/helm/test-app \
+    --wait --timeout \"1m\" \
+    --namespace \"$TEST_APP_NAMESPACE\" \
+    --set serviceAccount.name=\"$TEST_APP_SA\" \
+    --set conjur.configurationVersion=0.2.0 \
+    --set conjur.sslCertificate=\"$(cat ./system/haproxy/certs/conjur-master.mycompany.local.pem)\" \
+    --set conjur.applianceUrl=\"https://conjur-master.mycompany.local\" \
+    --set conjur.account=\"demo\" \
+    --set conjur.authnId=\"dev-cluster\" \
+    --set conjur.secrets=\"- \"relative/path/fileA.txt\": \"db-credentials/url\"
+- \"relative/path/fileB.txt\": \"db-credentials/username\"
+- \"relative/path/fileC.txt\": \"db-credentials/password\"\"
+"
 }
 
 #
@@ -848,6 +944,7 @@ while true ; do
     --promote-standby ) CMD='_perform_promotion' ; shift ;;
     --provision-follower ) CMD='_setup_follower' ; shift ;;
     --provision-k8s-follower ) CMD='_setup_k8s_follower' ; shift ;;
+    --provision-csi-provider ) CMD='_setup_csi_provider' ; shift ;;
     --provision-master ) CMD='_single_master' ; shift ;;
     --provision-standbys ) CMD='_setup_standbys' ; shift ;;
     --provision-keycloak ) CMD='_setup_keycloak' ; shift ;;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,18 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./system/haproxy/certs:/etc/ssl/certs
 
+  csi-provider-orchestrator:
+    build:
+      context: artifacts/k8s-csi-provider
+    privileged: true
+    networks:
+      dap_net:
+    volumes:
+      - ./kubeconfig:/root/.kube/config
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./system/haproxy/certs:/etc/ssl/certs
+      - ./artifacts:/artifacts
+
   follower-client:
     image: cyberark/conjur-cli:8
     networks:


### PR DESCRIPTION
Adds the flag `--provision-csi-provider` to run an example workflow configuring a kind cluster with the Conjur provider for CSI Secrets Store Driver. This requires a configured master, and deploys a test app to validate that secrets can be retrieved and mounted into an application pod using a service account token and authn-jwt.