### PR TITLE
CNJR-9173: Migrate burn-in test dynamic secrets HTTP calls to CLI calls

### DIFF
--- a/tools/performance-tests/k6/Dockerfile
+++ b/tools/performance-tests/k6/Dockerfile
@@ -23,7 +23,7 @@ RUN xk6 build \
     --with github.com/grafana/xk6-exec@latest
 
 # Install Conjur CLI
-RUN wget https://github.com/cyberark/conjur-cli-go/releases/download/v8.0.19/conjur_linux_amd64 && \
+RUN wget https://github.com/cyberark/conjur-cli-go/releases/download/v8.1.2/conjur_linux_amd64 && \
   mv conjur_linux_amd64 conjur && \
   chmod +x conjur
 

--- a/tools/performance-tests/k6/modules/api.js
+++ b/tools/performance-tests/k6/modules/api.js
@@ -115,38 +115,6 @@ export function writeSecret(client, data, resourceId, resourceBody) {
   );
 }
 
-export function createAwsIssuer(client, data, name, accessKeyId, awsSecretAccessKey) {
-  const {
-    applianceMasterUrl,
-    conjurAccount,
-    token
-  } = data;
-  const headers = {
-    'Authorization': `Token token="${token}"`,
-    'Content-Type': 'application/json'
-  };
-  const body = {
-    id: name,
-    max_ttl: 3600,
-    type: "aws",
-    data: {
-      access_key_id: accessKeyId,
-      secret_access_key: awsSecretAccessKey
-    }
-  };
-  const payload =  JSON.stringify(body);
-
-  return client.post(
-    `${applianceMasterUrl}/api/issuers/${conjurAccount}`,
-    payload,
-    {
-      headers,
-      timeout: '1h',
-      tags: {endpoint: 'PostIssuersURL'},
-    }
-  );
-}
-
 export function get(client, data, path) {
   const {
     applianceReadUrl,


### PR DESCRIPTION
The desired outcome of this PR is to use the updated Conjur CLI for all relevant dynamic secret interactions, rather than the HTTP API directly. This is to better support end-to-end testing of our product now that the Conjur CLI supports dynamic secrets and issuer interactions.