### PR TITLE
Fix dynamic secrets test setup

### DIFF
--- a/tools/performance-tests/k6/modules/api.js
+++ b/tools/performance-tests/k6/modules/api.js
@@ -115,6 +115,38 @@ export function writeSecret(client, data, resourceId, resourceBody) {
   );
 }
 
+export function createAwsIssuer(client, data, name, accessKeyId, awsSecretAccessKey) {
+  const {
+    applianceMasterUrl,
+    conjurAccount,
+    token
+  } = data;
+  const headers = {
+    'Authorization': `Token token="${token}"`,
+    'Content-Type': 'application/json'
+  };
+  const body = {
+    id: name,
+    max_ttl: 3600,
+    type: "aws",
+    data: {
+      access_key_id: accessKeyId,
+      secret_access_key: awsSecretAccessKey
+    }
+  };
+  const payload =  JSON.stringify(body);
+
+  return client.post(
+    `${applianceMasterUrl}/api/issuers/${conjurAccount}`,
+    payload,
+    {
+      headers,
+      timeout: '1h',
+      tags: {endpoint: 'PostIssuersURL'},
+    }
+  );
+}
+
 export function get(client, data, path) {
   const {
     applianceReadUrl,


### PR DESCRIPTION
Re-adds the js api method for `createAwsIssuer`. This is used by the `tools/performance-tests/k6/scenarios/static-dynamic-secrets/create-dynamic-secrets-policy.js` script, which is required to be run before `tools/performance-tests/k6/scenarios/static-dynamic-secrets/read-dynamic-secrets.js` can execute successfully.